### PR TITLE
Clicking between nav options repositions dragged window

### DIFF
--- a/packages/web/components/DesktopWindow.tsx
+++ b/packages/web/components/DesktopWindow.tsx
@@ -69,10 +69,11 @@ const DesktopWindow = ({
 
   const shouldBeDraggable = !isTouchDevice() && !isFullScreen;
 
-  const handleStop = (e: DraggableEventHandler) => {
+  const handleStop = () => {
     const el = document.querySelector('.floating');
     if (el && el.getAttribute('style')) {
-      windowPosition.updatePosition(el.getAttribute('style'));
+      const transformValue = el.getAttribute('style') || '';
+      windowPosition.updatePosition(transformValue);
     }
   }
 

--- a/packages/web/src/WindowPosition.ts
+++ b/packages/web/src/WindowPosition.ts
@@ -1,6 +1,7 @@
 import { makeVar } from '@apollo/client';
 
 class WindowPosition {
+  position?: any;
   constructor() {
     this.position = undefined;
   }


### PR DESCRIPTION
Link to ticket
https://dope-wars.notion.site/f6e68234cb3145f3a02ae8d215e9f63f?v=762e20115798400891f1ee68a0229636&p=86f3b981da3d481ba57c228d11d41e92

When changing tabs in the DOPEWARS.EXE or switching between windows, the desktop window repositions.

I attempted to fix this by capturing the X and Y result provided by the draggable API, but it depends on the mouse pointer's position
![draggable_pointless_positioning_results](https://user-images.githubusercontent.com/16459104/136718273-b319a0cd-b830-4470-ab9e-2935aff2728f.gif)

Trying to save the position from that result was futile, so instead I captured the last CSS transform value set on the DOM object
![draggable_capture_transform_value](https://user-images.githubusercontent.com/16459104/136718344-2dc55858-c40f-4969-91ba-f54842636f2a.gif)

This works great, but there could be situations where the Close Window button appears offscreen due to varying window sizes

![save_position_2](https://user-images.githubusercontent.com/16459104/136718393-b2aac2e0-fe1b-4db2-a4d4-ed0e0a294b5f.gif)
