### PR TITLE
Implement sticky footer in loot table panel

### DIFF
--- a/packages/web/components/loot/LootTable.tsx
+++ b/packages/web/components/loot/LootTable.tsx
@@ -83,44 +83,72 @@ const LootTable = ({ className = '', data, selected, onSelect }: Props) => {
         }
       `}
     >
-      <Table variant="dope">
-        <colgroup>
-          <col width="25%" />
-          <col width="25%" />
-          {/* <col width="25%" /> */}
-          <col width="25%" />
-        </colgroup>
-        <Thead>
-          <Tr>
-            <Th onClick={() => setSort('id')}>Dope ID</Th>
-            <Th onClick={() => setSort('rank')}>Rank</Th>
-            {/* <Th onClick={() => setSort('percentile')}>Percent</Th> */}
-            <Th>Paper?</Th>
-          </Tr>
-        </Thead>
-        <Tbody>
-          {items.map(({ id, rank, claimed, idx }) => (
-            <Tr
-              className={selected === idx ? 'selected' : ''}
-              key={id}
-              onClick={() => onSelect(idx)}
-            >
-              <Td>{id}</Td>
-              <Td>{rank}</Td>
-              <Td>{claimed}</Td>
-            </Tr>
-          ))}
-        </Tbody>
-        <Tfoot>
-          <Tr>
-            <Th colSpan={3}>
-              {items.length} DOPE {items.length > 1 ? 'Tokens' : 'Token'}
-              <span className="separator">/</span>
-              {formattedUnclaimedPaper()} Unclaimed $PAPER
-            </Th>
-          </Tr>
-        </Tfoot>
-      </Table>
+      <div
+        css={css`
+          display:flex;
+          min-height: 100%;
+          flex-direction: column;
+          align-items: stretch;
+          `}>
+          <div
+            css={css`
+              flex-grow: 1;
+              `}>
+              <Table variant="dope">
+                <colgroup>
+                  <col width="25%" />
+                  <col width="25%" />
+                  {/* <col width="25%" /> */}
+                  <col width="25%" />
+                </colgroup>
+                <Thead>
+                  <Tr>
+                    <Th onClick={() => setSort('id')}>Dope ID</Th>
+                    <Th onClick={() => setSort('rank')}>Rank</Th>
+                    {/* <Th onClick={() => setSort('percentile')}>Percent</Th> */}
+                    <Th>Paper?</Th>
+                  </Tr>
+                </Thead>
+                <Tbody>
+                  {items.map(({ id, rank, claimed, idx }) => (
+                    <Tr
+                      className={selected === idx ? 'selected' : ''}
+                      key={id}
+                      onClick={() => onSelect(idx)}
+                    >
+                      <Td>{id}</Td>
+                      <Td>{rank}</Td>
+                      <Td>{claimed}</Td>
+                    </Tr>
+                  ))}
+                </Tbody>
+              </Table>
+          </div>
+          <div
+            css={css`
+              position: sticky;
+              bottom: 0;
+              `}>
+              <Table variant="dope">
+                <colgroup>
+                  <col width="25%" />
+                  <col width="25%" />
+                  <col width="25%" />
+                </colgroup>
+                <Thead></Thead>
+                <Tbody></Tbody>
+                <Tfoot>
+                  <Tr>
+                    <Th colSpan={3}>
+                      {items.length} DOPE {items.length > 1 ? 'Tokens' : 'Token'}
+                      <span className="separator">/</span>
+                      {formattedUnclaimedPaper()} Unclaimed $PAPER
+                    </Th>
+                  </Tr>
+                </Tfoot>
+              </Table>
+          </div>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
Link to ticket
https://dope-wars.notion.site/f6e68234cb3145f3a02ae8d215e9f63f?v=762e20115798400891f1ee68a0229636&p=d95e607a9f714c32b4b7400905a1ceac

Tested in Chrome and Firefox

Instead of refactoring too much, I just split out the footer into its own table wrapped in a flexbox div

### Before HTML structure

```
<div>
  <table>
    <head></head>
    <body></body>
    <footer></footer>
  </table>
</div>
```

### After structure
```
<div style="display:flex;min-height: 100%;flex-direction: column;align-items: stretch;">
  <div style="flex-grow: 1;">
    <table>
      <head></head>
      <body></body>
    </table>
  </div>
  <div style="position:sticky;bottom:0;">
    <table>
      <footer></footer>
    </table>
  </div>
</div>
```

Hopefully the CSS and structure changes are self explanitory. The current style seemed to prefer embedded styles, probably due to the dynamic class naming, so I kept that pattern.

### Before
![loot_table_0](https://user-images.githubusercontent.com/16459104/136892273-28b86f51-7e86-47c5-bac7-aa098908927f.png)

### After(100vh)
![loot_table_fix_0](https://user-images.githubusercontent.com/16459104/136892311-15410e29-e196-4dd1-bfa5-4d0dc8f4f7a4.png)

### What it looks like with more items
![loot_table_whale_free_loot_view](https://user-images.githubusercontent.com/16459104/136892547-c9153142-592f-456f-a220-161d6243f989.gif)

### Changing mixins
![loot_table_squish](https://user-images.githubusercontent.com/16459104/136892600-16c417b1-3918-44c6-b507-27aada1f1495.gif)

I went with 100% instead of the reccommended 100vh... because I like it more? What do you think @subimage 
![loot_table_percentage_vs_vh](https://user-images.githubusercontent.com/16459104/136892715-c8b3419d-cd3c-4381-bcbf-04ef44a65ea0.gif)

