### PR TITLE
Multiple cosmetic issues addressed

### DIFF
--- a/packages/web/components/hustler/ConfigurationControls.tsx
+++ b/packages/web/components/hustler/ConfigurationControls.tsx
@@ -1,13 +1,12 @@
 import { Button, HStack, Stack } from '@chakra-ui/react';
 import { useReactiveVar } from '@apollo/client';
-import { useRouter } from 'next/router';
 import {
   HustlerInitConfig,
   randomizeHustlerAttributes,
-  HustlerCustomization,
   DEFAULT_BG_COLORS,
   DEFAULT_TEXT_COLORS,
   SKIN_TONE_COLORS,
+  ZOOM_WINDOWS,
 } from 'src/HustlerConfig';
 import { useEffect, useState } from 'react';
 import HairSelector from './HairSelector';
@@ -17,19 +16,21 @@ import SexSelector from './SexSelector';
 import PanelColorSelector from 'components/PanelColorSelector';
 
 const ConfigurationControls = () => {
-  const router = useRouter();
   const hustlerConfig = useReactiveVar(HustlerInitConfig);
 
   const [showTextColor, setShowTextColor] = useState(false);
+  const [showNameControls, setShowNameControls] = useState(false);
 
   useEffect(() => {
     setShowTextColor(hustlerConfig.renderName == true || hustlerConfig.renderTitle == true);
+    setShowNameControls(hustlerConfig.zoomWindow == ZOOM_WINDOWS[0]);
   }, [hustlerConfig]);
 
   return (
     <>
       <Stack spacing={4}>
-        <NameControls />
+        {/* Title controls only make sense when zoomed out fully */}
+        {showNameControls && <NameControls /> }
 
         {showTextColor && (
           <PanelColorSelector
@@ -65,13 +66,13 @@ const ConfigurationControls = () => {
 
         <SexSelector />
         <HairSelector />
-        <HStack mt={4} justify="end">
-          <Button onClick={() => randomizeHustlerAttributes()}>Randomize</Button>
-          <Button variant="primary">
-            Finish Configuration
-          </Button>
-        </HStack>
       </Stack>
+      <HStack mt={4} justify="end">
+        <Button onClick={() => randomizeHustlerAttributes()}>Randomize</Button>
+        <Button variant="primary">
+          Finish Configuration
+        </Button>
+      </HStack>
     </>
   );
 };

--- a/packages/web/components/hustler/InitiationFooterDopeContent.tsx
+++ b/packages/web/components/hustler/InitiationFooterDopeContent.tsx
@@ -1,6 +1,10 @@
-import { Button } from '@chakra-ui/button';
-import { Switch } from '@chakra-ui/switch';
-import { Spinner } from '@chakra-ui/spinner';
+import {
+  Button,
+  FormLabel,
+  Spinner,
+  Switch,
+} from '@chakra-ui/react';
+
 import { ChangeEvent } from 'react';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -155,7 +159,12 @@ const InitiationFooterDopeContent = () => {
         </SubPanelForm>
         <PanelFooter>
           <div>
-            <Switch isChecked={hustlerConfig.mintOg} onChange={handleOgSwitchChange} /> Initiate OG
+            <Switch 
+              id="initiate-og-switch"
+              isChecked={hustlerConfig.mintOg} 
+              onChange={handleOgSwitchChange} 
+            />
+            <label htmlFor="initiate-og-switch" css={css`margin-left:.5em;`}>Initiate OG</label>
           </div>
           <Button variant="primary" onClick={goToNextStep}>
             Continue Initiation

--- a/packages/web/features/hustlers/components/Stepper/index.tsx
+++ b/packages/web/features/hustlers/components/Stepper/index.tsx
@@ -1,6 +1,6 @@
 import useHustler from 'features/hustlers/hooks/useHustler';
 import useDispatchHustler from 'features/hustlers/hooks/useDispatchHustler';
-import CarretRight from 'svg/CarretRight';
+import ChevronRight from 'svg/ChevronRight';
 import { Wrapper, Item, Button } from './styles';
 
 const STEPS = [
@@ -72,7 +72,7 @@ const Stepper = () => {
     <Wrapper>
       {STEPS.map(({ step, title }, i) => (
         <>
-          <Item key={i}>
+          <Item key={`item-${i}`}>
             <Button
               type="button"
               onClick={() => goToStep(step)}
@@ -82,7 +82,7 @@ const Stepper = () => {
               {title}
             </Button>
           </Item>
-          {step < 2 && <CarretRight />}
+          {step < 2 && <ChevronRight key={`chevron-${i}`} />}
         </>
       ))}
     </Wrapper>

--- a/packages/web/features/hustlers/components/Stepper/styles.ts
+++ b/packages/web/features/hustlers/components/Stepper/styles.ts
@@ -4,13 +4,12 @@ export const Wrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 5px 111px;
+  padding: 4px 128px;
   border-bottom: 2px solid #1c1c1c;
   border-top: 2px solid #1c1c1c;
   position: fixed;
   width: 100%;
-  background: #d0d0d0;
-
+  background: #434345;
   @media (max-width: 640px) {
     width: 80%;
   }
@@ -21,7 +20,7 @@ type ButtonProps = {
 };
 
 export const Button = styled.button<ButtonProps>`
-  padding: 8px 16px;
+  padding: 4px 12px;
   border-radius: 8px;
   color: #ffffff;
 
@@ -30,10 +29,8 @@ export const Button = styled.button<ButtonProps>`
   }
 
   ${({ isActive }) =>
-    isActive &&
-    `
-    background: #434345;
-  `}
+    isActive && `background: #202221;`
+  }
 `;
 
 export const Item = styled.div``;

--- a/packages/web/features/hustlers/modules/Customize/index.tsx
+++ b/packages/web/features/hustlers/modules/Customize/index.tsx
@@ -14,8 +14,6 @@ const Customize = ({ hustlerConfig }: StepsProps) => (
       <PanelContainer
         css={css`
           min-height: 400px;
-          // This bg color will have to change once we can configure it
-          // It's the default right now for testnet renders.
           background-color: ${hustlerConfig.bgColor};
         `}
       >

--- a/packages/web/features/hustlers/modules/Finalize/index.tsx
+++ b/packages/web/features/hustlers/modules/Finalize/index.tsx
@@ -14,8 +14,6 @@ const Finalize = ({ hustlerConfig }: StepsProps) => (
       <PanelContainer
         css={css`
           min-height: 400px;
-          // This bg color will have to change once we can configure it
-          // It's the default right now for testnet renders.
           background-color: ${hustlerConfig.bgColor};
         `}
       >

--- a/packages/web/features/hustlers/modules/Initiate/index.tsx
+++ b/packages/web/features/hustlers/modules/Initiate/index.tsx
@@ -15,8 +15,6 @@ const Initiate = ({ hustlerConfig }: StepsProps) => (
       <PanelContainer
         css={css`
           min-height: 400px;
-          // This bg color will have to change once we can configure it
-          // It's the default right now for testnet renders.
           background-color: ${hustlerConfig.bgColor};
         `}
       >

--- a/packages/web/features/hustlers/modules/Steps/index.tsx
+++ b/packages/web/features/hustlers/modules/Steps/index.tsx
@@ -13,12 +13,11 @@ export type StepsProps = {
 };
 
 const Steps = ({ hustlerConfig }: StepsProps) => {
+  console.log(hustlerConfig);
   const hustler = useHustler();
 
   const stepToRender = () => {
     switch (hustler.currentStep) {
-      case 0:
-        return <Initiate hustlerConfig={hustlerConfig} />;
       case 1:
         return <Approve hustlerConfig={hustlerConfig} />;
       case 2:

--- a/packages/web/features/hustlers/modules/Steps/styles.ts
+++ b/packages/web/features/hustlers/modules/Steps/styles.ts
@@ -7,11 +7,10 @@ export const HustlerContainer = styled.div`
   display: flex;
   justify-content: flex-start;
   align-items: flex-start;
-  padding-top: 50px;
+  padding-top: 40px;
 
   .chakra-aspect-ratio > img {
     width: 400px;
-    height: 750px;
     margin: 0 auto;
   }
 

--- a/packages/web/pages/hustlers/initiate.tsx
+++ b/packages/web/pages/hustlers/initiate.tsx
@@ -6,7 +6,7 @@ import Steps from 'features/hustlers/modules/Steps';
 import HustlerProvider from 'features/hustlers/HustlerProvider';
 import AppWindow from 'components/AppWindow';
 import LoadingBlock from 'components/LoadingBlock';
-import Container from 'components/Container';
+import { css } from '@emotion/react';
 
 const InitiatePage = () => {
   const hustlerConfig = useReactiveVar(HustlerInitConfig);
@@ -26,10 +26,9 @@ const InitiatePage = () => {
       padBody={false}
     >
       {loading ? (
-        <Container>
+        <div css={css`padding:32px;`}>
           <LoadingBlock />
-          <LoadingBlock />
-        </Container>
+        </div>
       ) : (
         <HustlerProvider>
           <Steps hustlerConfig={hustlerConfig} />

--- a/packages/web/svg/ChevronRight.tsx
+++ b/packages/web/svg/ChevronRight.tsx
@@ -1,4 +1,4 @@
-const CarretRight = () => (
+const ChevronRight = () => (
   <svg width="10" height="17" viewBox="0 0 10 17" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path
       d="M9.905 8.572c0 .292-.112.585-.335.808l-6.857 6.856a1.142 1.142 0 1 1-1.616-1.616l6.05-6.048-6.05-6.05A1.142 1.142 0 1 1 2.715.906L9.57 7.763c.223.223.334.516.334.809Z"
@@ -7,4 +7,4 @@ const CarretRight = () => (
   </svg>
 );
 
-export default CarretRight;
+export default ChevronRight;


### PR DESCRIPTION
- [x]  Initiate loader has no padding
- [x]  Stepper component doesn't have keys defined for children
- [x]  Background Color of stepper seems off (white text doesn't have enough contrast)
- [x]  ZoomWindow is incorrect for hustler rendering (zoom instead of wide view on `/initiate`)
- [x]  Label for *Initiate OG* doesn't toggle switch on `/initiate`
- [x]  When zoomed in, does it make sense to show "title" and "name" controls?
(You can't see rendered name anyhow)