### PR TITLE
Remove switch for render title. Only use render name switch.

### DIFF
--- a/packages/web/components/hustler/ConfigurationControls.tsx
+++ b/packages/web/components/hustler/ConfigurationControls.tsx
@@ -21,7 +21,7 @@ const ConfigurationControls = () => {
   const [showNameControls, setShowNameControls] = useState(false);
 
   useEffect(() => {
-    setShowTextColor(hustlerConfig.renderName == true || hustlerConfig.renderTitle == true);
+    setShowTextColor(hustlerConfig.renderName == true);
     setShowNameControls(hustlerConfig.zoomWindow == ZOOM_WINDOWS[0]);
   }, [hustlerConfig]);
 

--- a/packages/web/components/hustler/HustlerPanel.tsx
+++ b/packages/web/components/hustler/HustlerPanel.tsx
@@ -26,7 +26,6 @@ const HustlerPanel = ({hustlerConfig, footer}: Props) => {
         id={hustlerConfig.dopeId}
         name={hustlerConfig.name}
         renderName={hustlerConfig.renderName}
-        renderTitle={hustlerConfig.renderTitle}
         sex={hustlerConfig.sex}
         textColor={hustlerConfig.textColor}
         zoomWindow={hustlerConfig.zoomWindow}

--- a/packages/web/components/hustler/NameControls.tsx
+++ b/packages/web/components/hustler/NameControls.tsx
@@ -52,9 +52,9 @@ const NameControls = () => {
       <PanelTitleBar>Display</PanelTitleBar>
       <PanelBody>
         <Stack spacing={FIELD_SPACING}>
-          <FormControl mb={2}>
-            <FormLabel htmlFor="name">Name</FormLabel>
-            <HStack>
+          <FormLabel htmlFor="name">Name</FormLabel>
+          <HStack>
+            <FormControl mb={2}>
               <Input
                 id="name"
                 placeholder="name"
@@ -65,20 +65,20 @@ const NameControls = () => {
                   setHustlerName(e.currentTarget.value)
                 }}
               />
-              <Box display="flex" alignItems="center" verticalAlign="center">
-                <Switch
-                  id="render-name"
-                  checked={hustlerConfig.renderName}
-                  onChange={e => {
-                    HustlerInitConfig({ ...hustlerConfig, renderName: e.target.checked });
-                  }}
-                />
-                <FormLabel htmlFor="render-name" ml="2" mt="1">
-                  Visible
-                </FormLabel>
-              </Box>
-            </HStack>
-          </FormControl>
+            </FormControl>
+            <FormControl display="flex" alignItems="center" verticalAlign="center">
+              <Switch
+                id="render-name"
+                checked={hustlerConfig.renderName}
+                onChange={e => {
+                  HustlerInitConfig({ ...hustlerConfig, renderName: e.target.checked });
+                }}
+              />
+              <FormLabel htmlFor="render-name" ml="2" mt="1">
+                Visible
+              </FormLabel>
+            </FormControl>
+          </HStack>
         </Stack>
       </PanelBody>
     </PanelContainer>

--- a/packages/web/components/hustler/NameControls.tsx
+++ b/packages/web/components/hustler/NameControls.tsx
@@ -3,6 +3,7 @@ import { useDebounce } from 'usehooks-ts';
 import { useReactiveVar } from '@apollo/client';
 import { useState, useEffect } from 'react';
 import {
+  Box,
   Input,
   HStack,
   FormControl,
@@ -53,43 +54,31 @@ const NameControls = () => {
         <Stack spacing={FIELD_SPACING}>
           <FormControl mb={2}>
             <FormLabel htmlFor="name">Name</FormLabel>
-            <Input
-              id="name"
-              placeholder="name"
-              maxLength={NAME_MAX_LENGTH}
-              value={hustlerName}
-              onChange={e => {
-                setNameFieldDirty(true);
-                setHustlerName(e.currentTarget.value)
-              }}
-            />
+            <HStack>
+              <Input
+                id="name"
+                placeholder="name"
+                maxLength={NAME_MAX_LENGTH}
+                value={hustlerName}
+                onChange={e => {
+                  setNameFieldDirty(true);
+                  setHustlerName(e.currentTarget.value)
+                }}
+              />
+              <Box display="flex" alignItems="center" verticalAlign="center">
+                <Switch
+                  id="render-name"
+                  checked={hustlerConfig.renderName}
+                  onChange={e => {
+                    HustlerInitConfig({ ...hustlerConfig, renderName: e.target.checked });
+                  }}
+                />
+                <FormLabel htmlFor="render-name" ml="2" mt="1">
+                  Visible
+                </FormLabel>
+              </Box>
+            </HStack>
           </FormControl>
-          <HStack>
-            <FormControl display="flex" alignItems="center">
-              <FormLabel htmlFor="render-title" mb="0">
-                Show Title?
-              </FormLabel>
-              <Switch
-                id="render-title"
-                checked={hustlerConfig.renderTitle}
-                onChange={e => {
-                  HustlerInitConfig({ ...hustlerConfig, renderTitle: e.target.checked });
-                }}
-              />
-            </FormControl>
-            <FormControl display="flex" alignItems="center">
-              <FormLabel htmlFor="render-name" mb="0">
-                Show Name?
-              </FormLabel>
-              <Switch
-                id="render-name"
-                checked={hustlerConfig.renderName}
-                onChange={e => {
-                  HustlerInitConfig({ ...hustlerConfig, renderName: e.target.checked });
-                }}
-              />
-            </FormControl>
-          </HStack>
         </Stack>
       </PanelBody>
     </PanelContainer>

--- a/packages/web/components/hustler/RenderFromItemIds.tsx
+++ b/packages/web/components/hustler/RenderFromItemIds.tsx
@@ -20,7 +20,6 @@ export interface HustlerRenderProps {
   itemIds: BigNumber[];
   name?: string;
   renderName?: boolean;
-  renderTitle?: boolean;
   sex?: HustlerSex;
   textColor?: string;
   zoomWindow: ZoomWindow;
@@ -34,7 +33,6 @@ const RenderFromItemIds = ({
   itemIds,
   name = '',
   renderName = false,
-  renderTitle = false,
   sex,
   textColor = '#000000',
   zoomWindow,
@@ -95,7 +93,7 @@ const RenderFromItemIds = ({
       const drugShadowHex = '0x00362f3729062b';
       hustlers
         .render(
-          renderTitle ? name : '', // title
+          renderName ? 'OG TITLE GOES HERE' : '', // title
           renderName ? name : '', // subtitle – should this be "name" ?
           64,
           hexColorToBase16(bgColor),
@@ -120,7 +118,6 @@ const RenderFromItemIds = ({
     textColor,
     bgColor,
     renderName,
-    renderTitle,
     zoomWindow,
   ]);
 

--- a/packages/web/components/hustler/RenderFromLootId.tsx
+++ b/packages/web/components/hustler/RenderFromLootId.tsx
@@ -18,7 +18,6 @@ const RenderFromLootId = ({
   id,
   name,
   renderName,
-  renderTitle,
   sex,
   textColor,
   zoomWindow,
@@ -46,7 +45,6 @@ const RenderFromLootId = ({
         itemIds={itemIds}
         name={name}
         renderName={renderName}
-        renderTitle={renderTitle}
         sex={sex}
         textColor={textColor}
         zoomWindow={zoomWindow}

--- a/packages/web/components/hustler/ZoomControls.tsx
+++ b/packages/web/components/hustler/ZoomControls.tsx
@@ -28,21 +28,29 @@ const ZoomControls = () => {
   const minIndex = 0
   const maxIndex = ZOOM_WINDOWS.length - 1;
 
-  // body: SKIN_TONE_COLORS.findIndex(el => el == color),
-  // 
-
   const decrementZoomWindowIndex = () => {
     let newIndex = currentIndex - 1;
     if (minIndex > newIndex) newIndex = maxIndex;
-    HustlerInitConfig({...hustlerConfig, zoomWindow: ZOOM_WINDOWS[newIndex] });
     setCurrentIndex(newIndex);
+    setHustlerConfig();
   }
 
   const incrementZoomWindowIndex = () => {
     let newIndex = currentIndex + 1;
     if (maxIndex < newIndex) newIndex = minIndex;
-    HustlerInitConfig({...hustlerConfig, zoomWindow: ZOOM_WINDOWS[newIndex] });
     setCurrentIndex(newIndex);
+    setHustlerConfig();
+  }
+
+  const setHustlerConfig = () => {
+    let renderName = hustlerConfig.renderName
+    // for mugshots doesn't make sense to render name, because it gets cut off.
+    if (currentIndex == 1) renderName = false;
+    HustlerInitConfig({
+      ...hustlerConfig, 
+      zoomWindow: ZOOM_WINDOWS[currentIndex],
+      renderName: renderName
+    });
   }
 
   return (

--- a/packages/web/features/hustlers/modules/Approve/index.tsx
+++ b/packages/web/features/hustlers/modules/Approve/index.tsx
@@ -167,7 +167,6 @@ const Approve = ({ hustlerConfig }: StepsProps) => {
       hair,
       name,
       renderName,
-      renderTitle,
       sex,
       textColor,
       zoomWindow,
@@ -187,14 +186,13 @@ const Approve = ({ hustlerConfig }: StepsProps) => {
 
     let bitoptions = 0;
 
-    if (renderTitle) {
-      bitoptions += 10;
-    }
-
     if (renderName) {
+      // title
+      bitoptions += 10;
+      // name
       bitoptions += 100;
     }
-
+    
     const options =
       '0x' +
       parseInt('' + bitoptions, 2)

--- a/packages/web/pages/hustlers/configure.tsx
+++ b/packages/web/pages/hustlers/configure.tsx
@@ -51,7 +51,6 @@ const Configure = () => {
             id={hustlerConfig.dopeId}
             name={hustlerConfig.name}
             renderName={hustlerConfig.renderName}
-            renderTitle={hustlerConfig.renderTitle}
             sex={hustlerConfig.sex}
             textColor={hustlerConfig.textColor}
             zoomWindow={hustlerConfig.zoomWindow}

--- a/packages/web/src/HustlerConfig.ts
+++ b/packages/web/src/HustlerConfig.ts
@@ -37,7 +37,6 @@ export type HustlerCustomization = {
   mintOg: boolean;
   name?: string;
   renderName?: boolean;
-  renderTitle?: boolean;
   sex: HustlerSex;
   textColor: string;
   zoomWindow: ZoomWindow;
@@ -63,7 +62,6 @@ export const getRandomHustler = (): HustlerCustomization => {
     mintOg: false,
     name: HUSTLER_NAMES[getRandomNumber(0, HUSTLER_NAMES.length - 1)],
     renderName: false,
-    renderTitle: false,
     sex: HUSTLER_SEXES[getRandomNumber(0, 1)] as HustlerSex,
     textColor: '#000000',
     zoomWindow: ZOOM_WINDOWS[0],


### PR DESCRIPTION
Remove switch to render title.
Just use the render name switch for both title and name.