### PR TITLE
Show bundled status in swap meet

### DIFF
--- a/packages/web/components/loot/LootCardBody.tsx
+++ b/packages/web/components/loot/LootCardBody.tsx
@@ -101,6 +101,14 @@ const LootCardBody = ({ bag }: Props) => {
           item="125,000"
         />
       )}
+      {!bag.opened && (
+        <Row
+          key="bundled"
+          color={itemBackgroundColors[itemBackgroundColors.length - 1]}
+          slot="Bundled"
+          item="Ready to Unpack"
+        />
+      )}
       {[
         ['Weapon', bag.weapon],
         ['Vehicle', bag.vehicle],


### PR DESCRIPTION
Ensure we show bundled items in swap meet so people don't get rugged

![image](https://user-images.githubusercontent.com/12508/142719206-a3d42e0f-3aee-4c11-846d-1da3db9d98a3.png)
