### PR TITLE
Rename files and terms from LOOT to DOPE

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -2,7 +2,7 @@
 
 ## The DOPE DAO DESKTOP
 
-Contains the DOPEWARS.EXE desktop to view your loot, unbundle, generate Hustlers, and buy/sell.
+Contains the DOPEWARS.EXE desktop to view your DOPE, unbundle, generate Hustlers, and buy/sell.
 
 ### Features
 

--- a/packages/web/components/DopeWarsExeNav.tsx
+++ b/packages/web/components/DopeWarsExeNav.tsx
@@ -49,8 +49,8 @@ const DopeWarsExeNav = () => {
       <NavLink href="/swap-meet">
         <a>Swap Meet</a>
       </NavLink>
-      <NavLink href="/loot">
-        <a>Loot</a>
+      <NavLink href="/dope">
+        <a>DOPE</a>
       </NavLink>
       <NavLink href="/hustlers">
         <a>Hustlers</a>

--- a/packages/web/components/EthereumApolloProvider.tsx
+++ b/packages/web/components/EthereumApolloProvider.tsx
@@ -12,7 +12,7 @@ import { ReactNode, useMemo } from 'react';
 import { useEffect } from 'react';
 import { useWeb3React } from '@web3-react/core';
 import DopeDatabase, { DopeDbCacheReactive } from 'src/DopeDatabase';
-import { valueFromCachedLoot } from 'src/DopeJsonParser';
+import { valueFromCachedDope } from 'src/DopeJsonParser';
 import { useEthereum, useOptimism } from 'hooks/web3';
 
 /**
@@ -40,39 +40,39 @@ function getClient(uri: string) {
           fields: {
             clothes(_, { readField }): string {
               const tokenId = readField('id') as number;
-              return valueFromCachedLoot(tokenId, 'clothes');
+              return valueFromCachedDope(tokenId, 'clothes');
             },
             foot(_, { readField }): string {
               const tokenId = readField('id') as number;
-              return valueFromCachedLoot(tokenId, 'foot');
+              return valueFromCachedDope(tokenId, 'foot');
             },
             hand(_, { readField }): string {
               const tokenId = readField('id') as number;
-              return valueFromCachedLoot(tokenId, 'hand');
+              return valueFromCachedDope(tokenId, 'hand');
             },
             drugs(_, { readField }): string {
               const tokenId = readField('id') as number;
-              return valueFromCachedLoot(tokenId, 'drugs');
+              return valueFromCachedDope(tokenId, 'drugs');
             },
             neck(_, { readField }): string {
               const tokenId = readField('id') as number;
-              return valueFromCachedLoot(tokenId, 'neck');
+              return valueFromCachedDope(tokenId, 'neck');
             },
             ring(_, { readField }): string {
               const tokenId = readField('id') as number;
-              return valueFromCachedLoot(tokenId, 'ring');
+              return valueFromCachedDope(tokenId, 'ring');
             },
             vehicle(_, { readField }): string {
               const tokenId = readField('id') as number;
-              return valueFromCachedLoot(tokenId, 'vehicle');
+              return valueFromCachedDope(tokenId, 'vehicle');
             },
             waist(_, { readField }): string {
               const tokenId = readField('id') as number;
-              return valueFromCachedLoot(tokenId, 'waist');
+              return valueFromCachedDope(tokenId, 'waist');
             },
             weapon(_, { readField }): string {
               const tokenId = readField('id') as number;
-              return valueFromCachedLoot(tokenId, 'weapon');
+              return valueFromCachedDope(tokenId, 'weapon');
             },
             rank: {
               keyArgs: false,

--- a/packages/web/components/dope/DopeCard.tsx
+++ b/packages/web/components/dope/DopeCard.tsx
@@ -2,10 +2,10 @@
 import { useState } from 'react';
 import { css } from '@emotion/react';
 import { PickedBag } from 'src/DopeDatabase';
-import LootCardBody from './LootCardBody';
-import LootCardFooterForMarket from './LootCardFooterForMarket';
-import LootCardFooterForOwner from './LootCardFooterForOwner';
-import LootLegend from './LootLegend';
+import DopeCardBody from './DopeCardBody';
+import DopeCardFooterForMarket from './DopeCardFooterForMarket';
+import DopeCardFooterForOwner from './DopeCardFooterForOwner';
+import DopeLegend from './DopeLegend';
 import PanelContainer from 'components/PanelContainer';
 import PanelFooter from 'components/PanelFooter';
 import PanelTitleBarFlex from 'components/PanelTitleBarFlex';
@@ -17,7 +17,7 @@ interface Props {
   showCollapse?: boolean;
 }
 
-const LootCard = ({
+const DopeCard = ({
   footer,
   bag,
   isExpanded: isExpandedProp = true,
@@ -53,16 +53,16 @@ const LootCard = ({
   return (
     <>
       {isItemLegendVisible && (
-        <LootLegend key={`loot-legend_${bag.id}`} toggleVisibility={toggleItemLegendVisibility} />
+        <DopeLegend key={`dope-legend_${bag.id}`} toggleVisibility={toggleItemLegendVisibility} />
       )}
       {!isItemLegendVisible && (
         <PanelContainer
-          key={`loot-card_${bag.id}`}
-          className={`lootCard ${isExpanded ? '' : 'collapsed'}`}
+          key={`dope-card_${bag.id}`}
+          className={`dopeCard ${isExpanded ? '' : 'collapsed'}`}
           css={css`
             &.collapsed {
               max-height: 225px;
-              .lootCardBody {
+              .dopeCardBody {
                 overflow-y: hidden;
               }
             }
@@ -74,7 +74,7 @@ const LootCard = ({
                 width: 32px;
               `}
             ></div>
-            <div>Dope Wars Loot #{bag.id}</div>
+            <div>DOPE #{bag.id}</div>
             <div
               css={css`
                 width: 32px;
@@ -83,15 +83,15 @@ const LootCard = ({
               {showCollapse && <ToggleButton />}
             </div>
           </PanelTitleBarFlex>
-          <LootCardBody bag={bag} />
+          <DopeCardBody bag={bag} />
           {footer && footer === 'for-owner' && (
             <PanelFooter>
-              <LootCardFooterForOwner bag={bag} toggleVisibility={toggleItemLegendVisibility} />
+              <DopeCardFooterForOwner bag={bag} toggleVisibility={toggleItemLegendVisibility} />
             </PanelFooter>
           )}
           {footer && footer === 'for-marketplace' && (
             <PanelFooter>
-              <LootCardFooterForMarket bag={bag} />
+              <DopeCardFooterForMarket bag={bag} />
             </PanelFooter>
           )}
         </PanelContainer>
@@ -100,4 +100,4 @@ const LootCard = ({
   );
 };
 
-export default LootCard;
+export default DopeCard;

--- a/packages/web/components/dope/DopeCardBody.tsx
+++ b/packages/web/components/dope/DopeCardBody.tsx
@@ -1,10 +1,10 @@
 import { css } from '@emotion/react';
-import { LootLegendBackgroundColors } from './LootLegend';
+import { DopeLegendBackgroundColors } from './DopeLegend';
 import ItemRarities from 'dope-metrics/output/item-rarities.json';
 import { PickedBag } from 'src/DopeDatabase';
 import { NUM_DOPE_TOKENS } from 'src/constants';
 
-const itemBackgroundColors = Object.values(LootLegendBackgroundColors);
+const itemBackgroundColors = Object.values(DopeLegendBackgroundColors);
 
 const betterItemName = (name = '') => {
   const quotedIndex = name.lastIndexOf('"');
@@ -81,10 +81,10 @@ interface Props {
   bag: PickedBag;
 }
 
-const LootCardBody = ({ bag }: Props) => {
+const DopeCardBody = ({ bag }: Props) => {
   return (
     <div
-      className="lootCardBody"
+      className="dopeCardBody"
       css={css`
         flex: 1;
         background: #fff;
@@ -146,4 +146,4 @@ const LootCardBody = ({ bag }: Props) => {
     </div>
   );
 };
-export default LootCardBody;
+export default DopeCardBody;

--- a/packages/web/components/dope/DopeCardFooterForMarket.tsx
+++ b/packages/web/components/dope/DopeCardFooterForMarket.tsx
@@ -43,7 +43,7 @@ const LastSaleOrNever = ({ bag }: FooterForMarketProps) => {
   return <></>;
 };
 
-const LootCardFooterForMarket = ({ bag }: FooterForMarketProps) => {
+const DopeCardFooterForMarket = ({ bag }: FooterForMarketProps) => {
   return (
     <>
       <div
@@ -59,4 +59,4 @@ const LootCardFooterForMarket = ({ bag }: FooterForMarketProps) => {
     </>
   );
 };
-export default LootCardFooterForMarket;
+export default DopeCardFooterForMarket;

--- a/packages/web/components/dope/DopeCardFooterForOwner.tsx
+++ b/packages/web/components/dope/DopeCardFooterForOwner.tsx
@@ -15,7 +15,7 @@ interface Props {
   toggleVisibility(): void;
 }
 
-const LootCardFooterForOwner = ({ bag, toggleVisibility }: Props) => {
+const DopeCardFooterForOwner = ({ bag, toggleVisibility }: Props) => {
   const { chainId, account } = useWeb3React();
 
   const paper = usePaper();
@@ -35,7 +35,7 @@ const LootCardFooterForOwner = ({ bag, toggleVisibility }: Props) => {
         Initiate Hustler
       </Button>
       {initiator && paper && account && chainId === 42 && (
-        <Button onClick={() => router.push(`/loot/${bag.id}/unbundle`)}>Unbundle</Button>
+        <Button onClick={() => router.push(`/dope/${bag.id}/unbundle`)}>Unbundle</Button>
       )}
       {paper && (
         <Button
@@ -68,4 +68,4 @@ const LootCardFooterForOwner = ({ bag, toggleVisibility }: Props) => {
     </div>
   );
 };
-export default LootCardFooterForOwner;
+export default DopeCardFooterForOwner;

--- a/packages/web/components/dope/DopeLegend.tsx
+++ b/packages/web/components/dope/DopeLegend.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { Button } from '@chakra-ui/button';
 import styled from '@emotion/styled';
 
-export const LootLegendBackgroundColors = {
+export const DopeLegendBackgroundColors = {
   Standard: '#fff',
   Basic: '#fff',
   Rare: 'rgba(18,171,23,0.15)',
@@ -12,7 +12,7 @@ export const LootLegendBackgroundColors = {
   'Black Market': 'rgba(255,252,63,0.5)',
 };
 
-const LootLegendContainer = styled.div`
+const DopeLegendContainer = styled.div`
   background: #fff;
   display: flex;
   flex-flow: column wrap;
@@ -27,7 +27,7 @@ const LootLegendContainer = styled.div`
   }
 `;
 
-const LootLegendItem = styled.div`
+const DopeLegendItem = styled.div`
   color: #000;
   padding: 8px;
   margin: 16px 0px;
@@ -37,9 +37,9 @@ interface Props {
   toggleVisibility(): void;
 }
 
-const LootLegend = ({ toggleVisibility }: Props) => {
+const DopeLegend = ({ toggleVisibility }: Props) => {
   return (
-    <LootLegendContainer>
+    <DopeLegendContainer>
       <h4>Item Rarity Legend</h4>
       <div
         css={css`
@@ -47,17 +47,17 @@ const LootLegend = ({ toggleVisibility }: Props) => {
           padding: 8px 16px;
         `}
       >
-        {Object.entries(LootLegendBackgroundColors)
+        {Object.entries(DopeLegendBackgroundColors)
           .map(([key, value]) => {
             return (
-              <LootLegendItem
+              <DopeLegendItem
                 css={css`
                   background-color: ${value};
                 `}
                 key={key}
               >
                 {key}
-              </LootLegendItem>
+              </DopeLegendItem>
             );
           })
           .reverse()
@@ -71,7 +71,7 @@ const LootLegend = ({ toggleVisibility }: Props) => {
       >
         <Button onClick={() => toggleVisibility()}>Close</Button>
       </div>
-    </LootLegendContainer>
+    </DopeLegendContainer>
   );
 };
-export default LootLegend;
+export default DopeLegend;

--- a/packages/web/components/dope/DopeTable.tsx
+++ b/packages/web/components/dope/DopeTable.tsx
@@ -17,7 +17,7 @@ interface Props {
   onSelect: (i: number) => void;
 }
 
-const LootTable = ({ className = '', data, selected, onSelect }: Props) => {
+const DopeTable = ({ className = '', data, selected, onSelect }: Props) => {
   const [sort, setSort] = useState('id');
 
   const amountOfUnclaimedPaper = (): number => {
@@ -177,4 +177,4 @@ const LootTable = ({ className = '', data, selected, onSelect }: Props) => {
   );
 };
 
-export default LootTable;
+export default DopeTable;

--- a/packages/web/components/dope/NoDopeCard.tsx
+++ b/packages/web/components/dope/NoDopeCard.tsx
@@ -1,11 +1,11 @@
-// Blank-slate state for the Loot screen,
+// Blank-slate state for the Dope screen,
 // encouraging visitors to go pick up some DOPE.
 import { Button } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
 import Image from 'next/image';
 import styled from '@emotion/styled';
 
-const NoLootContainer = styled.div`
+const NoDopeContainer = styled.div`
   width: 100%;
   height: 100%;
   background-color: #202222;
@@ -18,7 +18,7 @@ const NoLootContainer = styled.div`
   }
 `;
 
-const NoLootTitle = styled.div`
+const NoDopeTitle = styled.div`
   text-align: center;
   background-color: #000000;
   color: #ffffff;
@@ -26,7 +26,7 @@ const NoLootTitle = styled.div`
   line-height: 32px;
 `;
 
-const NoLootHustler = styled.div`
+const NoDopeHustler = styled.div`
   flex-grow: 2;
   background: url('/images/tile/chainlink.png') repeat;
   display: flex;
@@ -39,19 +39,19 @@ const NoLootHustler = styled.div`
   }
 `;
 
-const NoLootCard = () => {
+const NoDopeCard = () => {
   const router = useRouter();
   return (
-    <NoLootContainer>
-      <NoLootTitle>No Loot In Connected Wallet</NoLootTitle>
-      <NoLootHustler>
-        <Image src="/images/hustler/no-loot.svg" alt="no loot" width={112} height={350} />
+    <NoDopeContainer>
+      <NoDopeTitle>No Dope In Connected Wallet</NoDopeTitle>
+      <NoDopeHustler>
+        <Image src="/images/hustler/no-dope.svg" alt="no dope" width={112} height={350} />
         <Button variant="primary" onClick={() => router.push('/swap-meet')}>
           Shop The Market
         </Button>
-      </NoLootHustler>
-    </NoLootContainer>
+      </NoDopeHustler>
+    </NoDopeContainer>
   );
 };
 
-export default NoLootCard;
+export default NoDopeCard;

--- a/packages/web/components/dope/RenderDope.tsx
+++ b/packages/web/components/dope/RenderDope.tsx
@@ -12,7 +12,7 @@ type Metadata = {
   image: string;
 };
 
-const RenderLoot = ({ itemIds }: { itemIds?: BigNumber[] }) => {
+const RenderDope = ({ itemIds }: { itemIds?: BigNumber[] }) => {
   const bgColor = DEFAULT_BG_COLORS[1];
   const [json, setJson] = useState<Metadata>();
   const [itemRles, setItemRles] = useState<string[]>([]);
@@ -66,4 +66,4 @@ const RenderLoot = ({ itemIds }: { itemIds?: BigNumber[] }) => {
   );
 };
 
-export default RenderLoot;
+export default RenderDope;

--- a/packages/web/components/hustler/HustlerPanel.tsx
+++ b/packages/web/components/hustler/HustlerPanel.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { HustlerCustomization } from 'src/HustlerConfig';
 import PanelContainer from 'components/PanelContainer';
 import PanelTitleBar from 'components/PanelTitleBar';
-import RenderFromLootId from 'components/hustler/RenderFromLootId';
+import RenderFromDopeId from 'components/hustler/RenderFromDopeId';
 
 interface Props {
   hustlerConfig: HustlerCustomization;
@@ -18,7 +18,7 @@ const HustlerPanel = ({ hustlerConfig, footer }: Props) => {
       `}
     >
       <PanelTitleBar>Hustler</PanelTitleBar>
-      <RenderFromLootId
+      <RenderFromDopeId
         bgColor={hustlerConfig.bgColor}
         body={hustlerConfig.body}
         facialHair={hustlerConfig.facialHair}

--- a/packages/web/components/hustler/InitiationFooterDopeContent.tsx
+++ b/packages/web/components/hustler/InitiationFooterDopeContent.tsx
@@ -107,7 +107,7 @@ const InitiationFooterDopeContent = () => {
       <PanelFooter>
         <SpinnerContainer>
           <Spinner size="xs" />
-          Finding unbundled DOPE NFT loot in your wallet
+          Finding unbundled DOPE in your wallet
         </SpinnerContainer>
       </PanelFooter>
     );

--- a/packages/web/components/hustler/RenderFromDopeId.tsx
+++ b/packages/web/components/hustler/RenderFromDopeId.tsx
@@ -4,11 +4,11 @@ import RenderFromItemIds, { HustlerRenderProps } from 'components/hustler/Render
 import LoadingBlockSquareCentered from 'components/LoadingBlockSquareCentered';
 import { useSwapMeet } from 'hooks/contracts';
 
-interface RenderFromLootIdProps extends Omit<HustlerRenderProps, 'itemIds'> {
+interface RenderFromDopeIdProps extends Omit<HustlerRenderProps, 'itemIds'> {
   id: string;
 }
 
-const RenderFromLootId = ({
+const RenderFromDopeId = ({
   bgColor,
   body,
   facialHair,
@@ -19,7 +19,7 @@ const RenderFromLootId = ({
   sex,
   textColor,
   zoomWindow,
-}: RenderFromLootIdProps) => {
+}: RenderFromDopeIdProps) => {
   const [itemIds, setItemIds] = useState<BigNumber[]>();
 
   const swapmeet = useSwapMeet();
@@ -53,4 +53,4 @@ const RenderFromLootId = ({
   }
 };
 
-export default RenderFromLootId;
+export default RenderFromDopeId;

--- a/packages/web/pages/about.tsx
+++ b/packages/web/pages/about.tsx
@@ -69,7 +69,7 @@ DOPE WARS is also an ongoing NFT art project and experiment in decentralized pro
 
 ## DOPE NFT
 
-![DOPE LOOT NFT #0001](/images/dope-nft-1.svg#float-left)
+![DOPE NFT #0001](/images/dope-nft-1.svg#float-left)
 
 [A limited edition of 8,000 DOPE NFTs were created in September 2021.](https://opensea.io/collection/dope-v4) 
 
@@ -99,7 +99,7 @@ Hustlers and Dealers are created by unbundling your DOPE NFT, equipping them wit
 
 $PAPER was originally distributed through a claimable amount of 125,000 per $DOPE NFT. Each NFT allows a claim of 125,000 $PAPER once and only once – and regardless of the current holder the NFT does not allow for more than one claim. These claims are the only source of $PAPER’s supply currently. 
 
-To see if your Dope Wars Loot NFT is eligible please connect your wallet in DOPEWARS.EXE and view your Loot. If you need to obtain $PAPER, please do so from a site like [Dextools](https://www.dextools.io/app/ether/pair-explorer/0xad6d2f2cb7bf2c55c7493fd650d3a66a4c72c483).
+To see if your DOPE NFT is eligible please connect your wallet in DOPEWARS.EXE and view it. If you need to obtain $PAPER, please do so from a site like [Dextools](https://www.dextools.io/app/ether/pair-explorer/0xad6d2f2cb7bf2c55c7493fd650d3a66a4c72c483).
 
 ## What is the supply of $PAPER?
 
@@ -122,7 +122,7 @@ Very shortly, you’ll be able to [unbundle your items, create a PFP of your Dop
 ----
 
 ### The DOPE DAO is supported by gamers like you
-[Purchase DOPE NFT loot on OpenSea](https://opensea.io/collection/dope-v4) to claim your votes on DOPE DAO proposals and play the upcoming game.
+[Purchase DOPE on OpenSea](https://opensea.io/collection/dope-v4) to claim your votes on DOPE DAO proposals and play the upcoming game.
 
 ----
 

--- a/packages/web/pages/dope.tsx
+++ b/packages/web/pages/dope.tsx
@@ -6,9 +6,9 @@ import { media } from 'styles/mixins';
 import AppWindow from 'components/AppWindow';
 import Head from 'components/Head';
 import LoadingBlock from 'components/LoadingBlock';
-import LootCard from 'components/loot/LootCard';
-import LootTable from 'components/loot/LootTable';
-import NoLootCard from 'components/loot/NoLootCard';
+import DopeCard from 'components/dope/DopeCard';
+import DopeTable from 'components/dope/DopeTable';
+import NoDopeCard from 'components/dope/NoDopeCard';
 import DopeWarsExeNav from 'components/DopeWarsExeNav';
 
 const FlexFiftyContainer = styled.div`
@@ -39,7 +39,7 @@ const FlexFiftyContainer = styled.div`
   `}
 `;
 
-export default function LootWindow() {
+export default function DopeWindow() {
   const { account } = useWeb3React();
   const { data, loading } = useWalletQuery({
     variables: { id: account?.toLowerCase() || '' },
@@ -56,10 +56,10 @@ export default function LootWindow() {
           <LoadingBlock />
         </FlexFiftyContainer>
       ) : !data?.wallet?.bags || data.wallet.bags.length === 0 ? (
-        <NoLootCard />
+        <NoDopeCard />
       ) : (
         <FlexFiftyContainer>
-          <LootTable
+          <DopeTable
             data={data.wallet.bags.map(({ opened, claimed, id, rank }) => ({
               opened,
               claimed,
@@ -69,7 +69,7 @@ export default function LootWindow() {
             selected={selected}
             onSelect={setSelected}
           />
-          <LootCard bag={data.wallet.bags[selected]} footer="for-owner" />
+          <DopeCard bag={data.wallet.bags[selected]} footer="for-owner" />
         </FlexFiftyContainer>
       )}
     </AppWindow>

--- a/packages/web/pages/dope/[id]/index.tsx
+++ b/packages/web/pages/dope/[id]/index.tsx
@@ -5,7 +5,7 @@ import { useWalletQuery } from 'src/generated/graphql';
 import { HustlerInitConfig } from 'src/HustlerConfig';
 import { useRouter } from 'next/router';
 import DesktopWindow from 'components/DesktopWindow';
-import RenderFromLootId from 'components/hustler/RenderFromLootId';
+import RenderFromDopeId from 'components/hustler/RenderFromDopeId';
 import Head from 'components/Head';
 import Container from 'components/Container';
 import LoadingBlock from 'components/LoadingBlock';
@@ -23,7 +23,7 @@ const HustlerContainer = styled.div<{ bgColor: string }>`
   }
 `;
 
-const Loot = () => {
+const Dope = () => {
   const hustlerConfig = useReactiveVar(HustlerInitConfig);
   const router = useRouter();
   const { id } = router.query;
@@ -45,7 +45,7 @@ const Loot = () => {
         </Container>
       ) : (
         <HustlerContainer bgColor={hustlerConfig.bgColor}>
-          <RenderFromLootId
+          <RenderFromDopeId
             id={id?.toString() ?? '1'}
             sex={hustlerConfig.sex}
             body={hustlerConfig.body}
@@ -60,4 +60,4 @@ const Loot = () => {
   );
 };
 
-export default Loot;
+export default Dope;

--- a/packages/web/pages/dope/[id]/unbundle/index.tsx
+++ b/packages/web/pages/dope/[id]/unbundle/index.tsx
@@ -15,7 +15,7 @@ import MintTo from 'components/panels/MintTo';
 
 import { useInitiator, usePaper, useSwapMeet } from 'hooks/contracts';
 import router, { useRouter } from 'next/router';
-import RenderLoot from 'components/loot/RenderLoot';
+import RenderDope from 'components/dope/RenderDope';
 import AppWindow from 'components/AppWindow';
 
 const Approve = () => {
@@ -67,18 +67,18 @@ const Approve = () => {
     }
   }, [isPaperApproved, hasEnoughPaper, mintTo, mintAddress]);
 
-  const unbundleLoot = () => {
+  const unbundleDope = () => {
     if (!account) {
       return;
     }
 
     initiator
       .open(dopeId, mintAddress || account, 1000000)
-      .then(() => router.replace('/loot/unbundle-success'));
+      .then(() => router.replace('/dope/unbundle-success'));
   };
 
   return (
-    <AppWindow requiresWalletConnection={true} padBody={false} title="Unbundle Loot">
+    <AppWindow requiresWalletConnection={true} padBody={false} title="Unbundle Dope">
       <Head title="Approve spend" />
       <StackedResponsiveContainer>
         <Stack>
@@ -122,16 +122,16 @@ const Approve = () => {
             background-color: #000;
           `}
         >
-          <PanelTitleBar>Loot</PanelTitleBar>
-          <RenderLoot itemIds={itemIds} />
+          <PanelTitleBar>Dope</PanelTitleBar>
+          <RenderDope itemIds={itemIds} />
           <PanelFooter
             css={css`
               padding: 1em;
               position: relative;
             `}
           >
-            <Button variant="primary" onClick={unbundleLoot} disabled={!canMint}>
-              🔓 Unbundle Loot 🔓
+            <Button variant="primary" onClick={unbundleDope} disabled={!canMint}>
+              🔓 Unbundle Dope 🔓
             </Button>
           </PanelFooter>
         </PanelContainer>

--- a/packages/web/pages/dope/unbundle-success.tsx
+++ b/packages/web/pages/dope/unbundle-success.tsx
@@ -265,8 +265,8 @@ const UnbundleSuccess = () => {
         width="100%"
         justifyContent="end"
       >
-        <Link href="/loot" passHref>
-          <Button variant="primary">Unbundle More Loot</Button>
+        <Link href="/dope" passHref>
+          <Button variant="primary">Unbundle More</Button>
         </Link>
       </HStack>
     </>

--- a/packages/web/pages/hustlers/configure.tsx
+++ b/packages/web/pages/hustlers/configure.tsx
@@ -10,7 +10,7 @@ import Head from 'components/Head';
 import PanelContainer from 'components/PanelContainer';
 import PanelFooter from 'components/PanelFooter';
 import PanelTitleBar from 'components/PanelTitleBar';
-import RenderFromLootId from 'components/hustler/RenderFromLootId';
+import RenderFromDopeId from 'components/hustler/RenderFromDopeId';
 import StackedResponsiveContainer from 'components/StackedResponsiveContainer';
 import ZoomControls from 'components/hustler/ZoomControls';
 
@@ -39,7 +39,7 @@ const Configure = () => {
           `}
         >
           <PanelTitleBar>DOPE NFT #{hustlerConfig.dopeId}</PanelTitleBar>
-          <RenderFromLootId
+          <RenderFromDopeId
             bgColor={hustlerConfig.bgColor}
             body={hustlerConfig.body}
             facialHair={hustlerConfig.facialHair}

--- a/packages/web/pages/swap-meet.tsx
+++ b/packages/web/pages/swap-meet.tsx
@@ -9,7 +9,7 @@ import DopeWarsExeNav from 'components/DopeWarsExeNav';
 import AppWindow from 'components/AppWindow';
 import Head from 'components/Head';
 import LoadingBlock from 'components/LoadingBlock';
-import LootCard from 'components/loot/LootCard';
+import DopeCard from 'components/dope/DopeCard';
 import MarketFilterBar from 'components/MarketFilterBar';
 import DopeDatabase, {
   compareByHighestLastSale,
@@ -42,13 +42,13 @@ const Container = styled.div`
   height: 100%;
   overflow-y: scroll;
   overflow-x: hidden;
-  .lootGrid {
+  .dopeGrid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
     grid-column-gap: 16px;
     grid-row-gap: 16px;
   }
-  .lootCard {
+  .dopeCard {
     max-height: auto;
   }
   ${media.tablet`
@@ -170,11 +170,11 @@ const MarketList = () => {
             hasMore={filteredSortedItems.length > visibleItems.length}
             loader={<LoadingBlock key={`loader_${itemsVisible}`} />}
             useWindow={false}
-            className="lootGrid"
+            className="dopeGrid"
           >
             {visibleItems.map((bag: PickedBag) => (
-              <LootCard
-                key={`loot-card_${bag.id}_${viewCompactCards}`}
+              <DopeCard
+                key={`dope-card_${bag.id}_${viewCompactCards}`}
                 bag={bag}
                 footer="for-marketplace"
                 isExpanded={viewCompactCards ? false : true}

--- a/packages/web/src/DopeDatabase.ts
+++ b/packages/web/src/DopeDatabase.ts
@@ -93,10 +93,10 @@ class DopeDatabase {
   // so we save network requests calling The Graph.
   populateFromJson() {
     console.log('Populating DopeDatabase');
-    const lootJsonEntries = Object.entries(DopeJson);
+    const dopeJsonEntries = Object.entries(DopeJson);
     const tempDB = [];
-    for (let i = 0; i < lootJsonEntries.length; i++) {
-      const dopeAsset = lootJsonEntries[i][1];
+    for (let i = 0; i < dopeJsonEntries.length; i++) {
+      const dopeAsset = dopeJsonEntries[i][1];
       const tokenId = Object.keys(dopeAsset)[0];
       const values = Object.values(dopeAsset)[0];
       const dope = newEmptyBag();

--- a/packages/web/src/DopeJsonParser.ts
+++ b/packages/web/src/DopeJsonParser.ts
@@ -1,7 +1,7 @@
 // Cached output of all our existing loot items
 import DopeJson from 'dope-metrics/output/loot.json';
 
-export const valueFromCachedLoot = (tokenId: number, key: string) => {
+export const valueFromCachedDope = (tokenId: number, key: string) => {
   const value = DopeJson[tokenId - 1][tokenId][key];
   return value;
 };


### PR DESCRIPTION
This was hanging out on my chore list for awhile. To finally remove "LOOT" from everywhere we reference it.