### PR TITLE
Fix StickyNote link + Initiate Hustler Copy

### DIFF
--- a/packages/web/src/components/StickyNoteHustlerMint.tsx
+++ b/packages/web/src/components/StickyNoteHustlerMint.tsx
@@ -20,7 +20,7 @@ const StickyNoteHustlerMint = () => {
   return (
     <StickyNote maxWidth="312px">
       <h3>
-        <Link href="/dope" variation="primary">
+        <Link href="/hustlers/initiate" variation="primary">
           <a className="primary">👉 Initiate Your Hustler 👈</a>
         </Link>
       </h3>

--- a/packages/web/src/features/hustlers/modules/Approve/index.tsx
+++ b/packages/web/src/features/hustlers/modules/Approve/index.tsx
@@ -187,7 +187,7 @@ const Approve = ({ hustlerConfig, makeVarConfig }: StepsProps) => {
               `}
             >
               <Button variant="primary" onClick={mintHustler} disabled={!canMint}>
-                ✨ Initiate Hustler ✨
+                ✨ Mint Hustler ✨
               </Button>
             </PanelFooter>
           }


### PR DESCRIPTION
https://www.notion.so/dope-wars/Change-language-from-Initiate-Hustler-to-Mint-Hustler-on-last-step-of-Hustler-mint-7cd4942d01c241c3adc07b6c5ffd72bb

Also fixed sticky note link on homepage to go back to `/hustlers/initiate` where it went previously