### PR TITLE
feat(web): vehicle rendering

### DIFF
--- a/packages/web/src/features/hustlers/components/ConfigureHustler/index.tsx
+++ b/packages/web/src/features/hustlers/components/ConfigureHustler/index.tsx
@@ -156,6 +156,7 @@ const ConfigureHustler = ({
             zoomWindow={config.zoomWindow}
             ogTitle={ogTitle}
             dopeId={config.dopeId}
+            resolution={64}
           />
         ) : (
           <RenderFromDopeId
@@ -170,6 +171,7 @@ const ConfigureHustler = ({
             textColor={config.textColor}
             zoomWindow={config.zoomWindow}
             ogTitle={ogTitle}
+            resolution={64}
           />
         )}
         <PanelFooter

--- a/packages/web/src/hooks/contracts.ts
+++ b/packages/web/src/hooks/contracts.ts
@@ -146,45 +146,36 @@ export const useFetchMetadata = () => {
             hustler.address,
             BigNumber.from(METADATA_KEY).add(WEAPON_SLOT).toHexString(),
           )
-          .then(BigNumber.from)
           .then(BigNumber.from),
         provider
           .getStorageAt(
             hustler.address,
             BigNumber.from(METADATA_KEY).add(CLOTHES_SLOT).toHexString(),
           )
-          .then(BigNumber.from)
           .then(BigNumber.from),
         provider
           .getStorageAt(
             hustler.address,
             BigNumber.from(METADATA_KEY).add(VEHICLE_SLOT).toHexString(),
           )
-          .then(BigNumber.from)
           .then(BigNumber.from),
         provider
           .getStorageAt(hustler.address, BigNumber.from(METADATA_KEY).add(WAIST_SLOT).toHexString())
-          .then(BigNumber.from)
           .then(BigNumber.from),
         provider
           .getStorageAt(hustler.address, BigNumber.from(METADATA_KEY).add(FOOT_SLOT).toHexString())
-          .then(BigNumber.from)
           .then(BigNumber.from),
         provider
           .getStorageAt(hustler.address, BigNumber.from(METADATA_KEY).add(HAND_SLOT).toHexString())
-          .then(BigNumber.from)
           .then(BigNumber.from),
         provider
           .getStorageAt(hustler.address, BigNumber.from(METADATA_KEY).add(DRUGS_SLOT).toHexString())
-          .then(BigNumber.from)
           .then(BigNumber.from),
         provider
           .getStorageAt(hustler.address, BigNumber.from(METADATA_KEY).add(NECK_SLOT).toHexString())
-          .then(BigNumber.from)
           .then(BigNumber.from),
         provider
           .getStorageAt(hustler.address, BigNumber.from(METADATA_KEY).add(RING_SLOT).toHexString())
-          .then(BigNumber.from)
           .then(BigNumber.from),
         provider
           .getStorageAt(

--- a/packages/web/src/pages/hustlers/[id]/customize.tsx
+++ b/packages/web/src/pages/hustlers/[id]/customize.tsx
@@ -96,6 +96,7 @@ const HustlerEdit = ({ hustler }: HustlerEditProps) => {
         });
 
         const fetchedItemIds = [
+          metadata.vehicle,
           metadata.weapon,
           metadata.clothes,
           metadata.waist,


### PR DESCRIPTION
@smakosh this adds support for vehicle rendering. Basically, if the resolution is set to 160 here: https://github.com/dopedao/dope-monorepo/pull/200/files#diff-05d6ab3d20a68e5dd8ddaa17421f684bbc59444c105e0e5a53b8eb6e149dab7eR159

It will render the hustler with their vehicle. Right now it always does that, so it is missing:

1) Support a 3rd type of view, vehicle view. Right now that isn't easy to add because of how we use viewbox for inferring the views. Ideally we have a enum of view types, `HUSTLER, MUGSHOT, VEHICLE`, that we can toggle through (using arrows in the current implementation)
2) Add a toggle so this is only supported on testnet for now