### PR TITLE
feat: add hustler details/gear page version: 1

### DIFF
--- a/packages/web/src/features/hustlers/components/HustlerInformation/HustlerDetails.tsx
+++ b/packages/web/src/features/hustlers/components/HustlerInformation/HustlerDetails.tsx
@@ -1,0 +1,49 @@
+import { HustlerDetailsProps } from './HustlerInformationTabs';
+import { Button } from '@chakra-ui/react';
+import { 
+  ControlsWrapper,
+  ControlsBody,
+  PanelFooter,
+  LineContent,
+  LineKey,
+  LineValue 
+} from 'features/hustlers/components/HustlerInformation/styles';
+
+const formatHustlerDetails = ({ name, id, title, respect }: HustlerDetailsProps) => [
+  {
+    key: 'Name:',
+    value: name,
+  },
+  {
+    key: 'Id:',
+    value: `#${id}`,
+  },
+  {
+    key: 'Title:',
+    value: title,
+  },
+  {
+    key: 'Respect:',
+    value: respect,
+  },
+];
+
+const HustlerDetails = (props: HustlerDetailsProps) => (
+  <ControlsWrapper>
+    <ControlsBody>
+      {formatHustlerDetails(props).map(detail => (
+        <LineContent key={detail.key}>
+          <LineKey>{detail.key}</LineKey>
+          <LineValue>{detail.value}</LineValue>
+        </LineContent>
+      ))}
+    </ControlsBody>
+    <PanelFooter>
+      <Button type="button" loadingText="Processing...">
+        Change Appearance
+      </Button>
+    </PanelFooter>
+  </ControlsWrapper>
+);
+
+export default HustlerDetails;

--- a/packages/web/src/features/hustlers/components/HustlerInformation/HustlerGear.tsx
+++ b/packages/web/src/features/hustlers/components/HustlerInformation/HustlerGear.tsx
@@ -1,0 +1,121 @@
+import { css } from '@emotion/react';
+import { DopeLegendColors } from 'features/dope/components/DopeLegend';
+import { Hustler } from 'generated/graphql';
+import {
+  PanelFooter,
+  ControlsBody,
+  ControlsWrapper,
+  LineKey,
+  LineValue,
+  LineContent,
+} from 'features/hustlers/components/HustlerInformation/styles';
+import { Button } from '@chakra-ui/react';
+
+type BulletProps = {
+  color?: string;
+};
+
+const Bullet = ({ color }: BulletProps) => (
+  <div
+    css={css`
+      height: 10px;
+      width: 10px;
+      min-width: 10px;
+      border-radius: 50%;
+      margin-right: 8px;
+      background-color: ${color};
+      // necessary when 'align-items: top' to ensure proper alignment with text
+      margin-top: 4px;
+    `}
+  ></div>
+);
+
+const formatGears = ({
+  clothes,
+  drug,
+  ring,
+  vehicle,
+  weapon,
+  waist,
+  neck,
+  hand,
+  foot,
+}: Hustler) => [
+  {
+    key: 'Weapon:',
+    name: weapon?.name,
+    color: weapon && DopeLegendColors[weapon.tier],
+  },
+  {
+    key: 'Vehicule:',
+    name: vehicle?.name,
+    color: vehicle && DopeLegendColors[vehicle.tier],
+  },
+  {
+    key: 'Drug:',
+    name: drug?.name,
+    color: drug && DopeLegendColors[drug.tier],
+  },
+  {
+    key: 'Clothes:',
+    name: clothes?.name,
+    color: clothes && DopeLegendColors[clothes?.tier],
+  },
+  {
+    key: 'Hands:',
+    name: hand?.name,
+    color: hand && DopeLegendColors[hand?.tier],
+  },
+  {
+    key: 'Feet:',
+    name: foot?.name,
+    color: foot && DopeLegendColors[foot?.tier],
+  },
+  {
+    key: 'Neck:',
+    name: neck?.name,
+    color: neck && DopeLegendColors[neck?.tier],
+  },
+  {
+    key: 'Ring:',
+    name: ring?.name,
+    color: ring && DopeLegendColors[ring?.tier],
+  },
+  {
+    key: 'Waist:',
+    name: waist?.name,
+    color: waist && DopeLegendColors[waist?.tier],
+  },
+];
+
+const HustlerGear = (props: Hustler) => (
+  <ControlsWrapper>
+    <ControlsBody>
+      {formatGears(props).map((gear, index) => (
+        <LineContent
+          key={gear.key}
+          css={css`
+            background-color: ${index % 2 !== 0 ? '#EDEFEE' : 'inherit'};
+          `}
+        >
+          <LineKey>{gear.key}</LineKey>
+          <LineValue>
+            {gear?.color && <Bullet color={gear.color} />}
+            <div>{gear.name}</div>
+          </LineValue>
+        </LineContent>
+      ))}
+    </ControlsBody>
+    <PanelFooter>
+      <Button type="button" loadingText="Processing...">
+        Cancel
+      </Button>
+
+      <Button type="button" variant="primary" loadingText="Processing...">
+        Save changes
+      </Button>
+    </PanelFooter>
+  </ControlsWrapper>
+);
+
+export default HustlerGear;

--- a/packages/web/src/features/hustlers/components/HustlerInformation/HustlerInformationTabs.tsx
+++ b/packages/web/src/features/hustlers/components/HustlerInformation/HustlerInformationTabs.tsx
@@ -1,0 +1,53 @@
+import DopeTabs, { DopeTabType } from 'ui/components/DopeTabs';
+import HustlerDetails from './HustlerDetails';
+import HustlerGear from './HustlerGear';
+import { Hustler } from 'generated/graphql';
+
+type HustlerInformationTabsProps = {
+  huslter: Hustler;
+};
+
+export type HustlerDetailsProps = {
+  name: string;
+  id: string;
+  title: string;
+  respect: string;
+};
+
+const HustlerInformationTabs = ({ huslter }: HustlerInformationTabsProps) => {
+  const hustlerDetails = {
+    name: huslter.name || '',
+    id: huslter.id || '0',
+    title: huslter.title || '',
+    respect: '', //respect not returned from the backend at the moment
+  };
+
+  const tabs: DopeTabType[] = [
+    {
+      title: 'Details',
+      number: 0,
+      content: <HustlerDetails {...hustlerDetails} />,
+    },
+    {
+      title: 'Gear',
+      number: 0,
+      content: <HustlerGear {...huslter} />,
+    },
+    {
+      title: 'Activity',
+      number: 0,
+      content: (
+        <div>
+          <p>Soon ...</p>
+        </div>
+      ),
+    },
+  ];
+
+  return (<DopeTabs
+    tabs={tabs}
+    height="calc(100% - 38px)"
+  />);
+}
+
+export default HustlerInformationTabs;

--- a/packages/web/src/features/hustlers/components/HustlerInformation/actions/SellHustler.tsx
+++ b/packages/web/src/features/hustlers/components/HustlerInformation/actions/SellHustler.tsx
@@ -1,0 +1,21 @@
+import { Button } from '@chakra-ui/react';
+
+export type SellHustlerTypes = {
+  onClick?: () => void;
+};
+
+const SellHustler = ({ onClick } : SellHustlerTypes) => {
+  return (
+    <Button 
+      type="button"
+      variant="primary"
+      loadingText="Processing..."
+      w="100%"
+      onClick={onClick}
+    >
+      Sell
+    </Button>
+  );
+}
+
+export default SellHustler;

--- a/packages/web/src/features/hustlers/components/HustlerInformation/actions/index.tsx
+++ b/packages/web/src/features/hustlers/components/HustlerInformation/actions/index.tsx
@@ -1,0 +1,14 @@
+import SellHustler from 'features/hustlers/components/HustlerInformation/actions/SellHustler';
+import { ActionsContainer } from 'features/hustlers/components/HustlerInformation/actions/styles';
+
+const Actions = () => {
+  return (
+    <ActionsContainer>
+      <SellHustler 
+        onClick={() => {}}
+      />
+    </ActionsContainer>
+  );
+}
+
+export default Actions;

--- a/packages/web/src/features/hustlers/components/HustlerInformation/actions/styles.ts
+++ b/packages/web/src/features/hustlers/components/HustlerInformation/actions/styles.ts
@@ -1,0 +1,6 @@
+import styled from '@emotion/styled';
+
+export const ActionsContainer = styled.div`
+  padding: 18px;
+  width: 100%;
+`;

--- a/packages/web/src/features/hustlers/components/HustlerInformation/index.tsx
+++ b/packages/web/src/features/hustlers/components/HustlerInformation/index.tsx
@@ -1,0 +1,62 @@
+import { css } from '@emotion/react';
+import { BigNumber } from '@ethersproject/bignumber';
+import { HustlerCustomization } from 'utils/HustlerConfig';
+import HustlerInformationTabs from './HustlerInformationTabs';
+import PanelContainer from 'components/PanelContainer';
+import StackedResponsiveContainer from 'components/StackedResponsiveContainer';
+import RenderFromItemIds from 'components/hustler/RenderFromItemIds';
+import styled from '@emotion/styled';
+import { Hustler } from 'generated/graphql';
+import HustlerActions from './actions/index';
+
+export type DetailsHustlerProps = {
+  huslter: Hustler;
+  ogTitle?: string;
+  itemIds?: BigNumber[];
+  config: HustlerCustomization;
+};
+
+const HustlerCard = styled.div<{ bgColor?: string }>(props => ({
+  backgroundColor: props.bgColor || '',
+  margin: '16px 16px 0 16px',
+  border: '2px solid #000000',
+  borderRadius: '4px',
+  height: 'calc(100% - 60px - 16px)',
+}));
+
+const ConfigureInformations = ({ huslter, config, itemIds, ogTitle }: DetailsHustlerProps) => {
+  return (
+    <StackedResponsiveContainer>
+      <PanelContainer
+        css={css`
+          min-height: 500px;
+          background-color: #edefee;
+        `}
+      >
+        <HustlerCard bgColor={config.bgColor}>
+          {itemIds && (
+            <RenderFromItemIds
+              bgColor={config.bgColor}
+              body={config.body}
+              facialHair={config.facialHair}
+              hair={config.hair}
+              itemIds={itemIds}
+              name={config.name}
+              renderName={config.renderName}
+              sex={config.sex}
+              textColor={config.textColor}
+              zoomWindow={config.zoomWindow}
+              ogTitle={ogTitle}
+              dopeId={config.dopeId}
+              isVehicle={config.isVehicle}
+            />
+          )}
+        </HustlerCard>
+        <HustlerActions />
+      </PanelContainer>
+      <HustlerInformationTabs huslter={huslter} />
+    </StackedResponsiveContainer>
+  );
+};
+
+export default ConfigureInformations;

--- a/packages/web/src/features/hustlers/components/HustlerInformation/styles.ts
+++ b/packages/web/src/features/hustlers/components/HustlerInformation/styles.ts
@@ -1,0 +1,59 @@
+import styled from '@emotion/styled';
+
+export const ControlsWrapper = styled.div`
+    background-color: white;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    border: 2px solid black;
+    position: relative;
+    height: 100%;
+`;
+
+export const ControlsBody = styled.div`
+    height: calc(100% - 56px);
+    overflow-y: auto;
+`;
+
+export const PanelFooter = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: #dededd;
+    border-top: 2px solid #000;
+    padding: 11px;
+    div {
+    flex-grow: 1;
+    }
+    * > button {
+    margin-right: 10px;
+    &:last-of-type {
+        margin: 0;
+    }
+    }
+    @media (max-width: 768px) {
+    display: flex;
+    flex-direction: column;
+    button {
+        width: 100%;
+        margin: 0 0 14px 0;
+    }
+    }
+`;
+
+export const LineContent = styled.div`
+    width: 100%;
+    height: 47px;
+    display: flex;
+    border-bottom: 1px solid #dededd;
+`;
+
+export const LineKey = styled.div`
+    padding: 16px;
+    width: 136px;
+`;
+
+export const LineValue = styled.div`
+    padding: 16px;
+    width: 100%;
+`;

--- a/packages/web/src/pages/hustlers/[id]/details.tsx
+++ b/packages/web/src/pages/hustlers/[id]/details.tsx
@@ -1,0 +1,205 @@
+/* eslint-disable @next/next/no-img-element */
+import { useEffect, useState } from 'react';
+import { BigNumber } from 'ethers';
+import styled from '@emotion/styled';
+import { Button } from '@chakra-ui/button';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { Image } from '@chakra-ui/image';
+import { useWeb3React } from '@web3-react/core';
+import { CloseButton } from '@chakra-ui/close-button';
+import { css } from '@emotion/react';
+import { Hustler, useHustlerQuery, useWalletQuery } from 'generated/graphql';
+import { getRandomHustler } from 'utils/HustlerConfig';
+import { media } from 'ui/styles/mixins';
+import { useFetchMetadata } from 'hooks/contracts';
+import { useSwitchOptimism } from 'hooks/web3';
+import AppWindow from 'components/AppWindow';
+import AppWindowNavBar from 'components/AppWindowNavBar';
+import Head from 'components/Head';
+import LoadingBlock from 'components/LoadingBlock';
+import StickyNote from 'components/StickyNote';
+import InformationsHustler from 'features/hustlers/components/HustlerInformation';
+
+const brickBackground = "#000000 url('/images/tile/brick-black.png') center/25% fixed";
+
+const Container = styled.div`
+  padding: 32px 16px;
+  height: 100%;
+  overflow-y: scroll;
+  overflow-x: hidden;
+  background: ${brickBackground};
+  .hustlerGrid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+    grid-column-gap: 32px;
+    grid-row-gap: 64px;
+  }
+  ${media.tablet`
+    padding: 32px;
+  `}
+`;
+
+const ContentLoading = () => (
+  <Container>
+    <LoadingBlock color="white" maxRows={10} />
+  </Container>
+);
+
+type HustlerEditProps = {
+  hustler: Hustler;
+};
+
+const HustlerInformations = ({ hustler }: HustlerEditProps) => {
+  const router = useRouter();
+  const [isLoading, setLoading] = useState(true);
+  const [itemIds, setItemIds] = useState<BigNumber[]>();
+  const [hustlerConfig, setHustlerConfig] = useState(getRandomHustler({}));
+
+  const fetchMetadata = useFetchMetadata();
+
+  useEffect(() => {
+    const fetch = async () => {
+      try {
+        const metadata = await fetchMetadata(BigNumber.from(hustler.id));
+
+        if (!metadata) {
+          // error occured
+          return;
+        }
+
+        setHustlerConfig(
+          getRandomHustler({
+            renderName: Boolean(hustler.name && hustler.name.length > 0),
+            name: metadata.name,
+            dopeId: hustler.id,
+            sex: metadata.body[0].eq(0) ? 'male' : 'female',
+            textColor: `#${metadata.color.slice(2, -2)}`,
+            bgColor: `#${metadata.background.slice(2, -2).toUpperCase()}`,
+            body: metadata.body[1],
+            hair: metadata.body[2],
+            facialHair: metadata.body[3],
+          }),
+        );
+
+        const fetchedItemIds = [
+          metadata.vehicle,
+          metadata.weapon,
+          metadata.clothes,
+          metadata.waist,
+          metadata.foot,
+          metadata.hand,
+          metadata.drugs,
+          metadata.neck,
+          metadata.ring,
+        ];
+
+        setItemIds(fetchedItemIds);
+
+        setLoading(false);
+      } catch (error) {
+        router.push('/404');
+      }
+    };
+
+    fetch();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hustler]);
+
+  return isLoading ? (
+    <ContentLoading />
+  ) : (
+    <>
+      <InformationsHustler
+        config={hustlerConfig}
+        huslter={hustler}
+        itemIds={itemIds}
+        ogTitle={hustler.title || ''}
+      />
+    </>
+  );
+};
+
+const Nav = () => (
+  <AppWindowNavBar>
+    <Link href="/hustlers" passHref>
+      <Button variant="back">
+        <Image src="/images/icon/arrow-back.svg" width="16px" alt="Arrow" />
+        Your Hustlers
+      </Button>
+    </Link>
+  </AppWindowNavBar>
+);
+
+export default function Details() {
+  const router = useRouter();
+
+  const [showNetworkAlert, setShowNetworkAlert] = useState(false);
+  const { account, chainId } = useWeb3React();
+
+  const { isFetching: walletLoading } = useWalletQuery(
+    {
+      where: {
+        id: account,
+      },
+    },
+    {
+      enabled: !!account,
+    },
+  );
+  const { data, isFetching: loading } = useHustlerQuery(
+    {
+      where: {
+        id: String(router.query.id),
+      },
+    },
+    {
+      enabled: !!account && router.isReady && !!String(router.query.id),
+    },
+  );
+  useSwitchOptimism(chainId, account);
+
+  useEffect(() => {
+    const localNetworkAlert = localStorage.getItem('networkAlertCustomizeHustler');
+
+    if (localNetworkAlert !== 'true') {
+      setShowNetworkAlert(true);
+    }
+  }, []);
+
+  const handleCloseAlert = () => {
+    window.localStorage.setItem('networkAlertCustomizeHustler', 'false');
+    setShowNetworkAlert(false);
+  };
+
+  return (
+    <AppWindow padBody={false} navbar={<Nav />} requiresWalletConnection={true}>
+      <Head title="Your Hustler Squad" />
+      {account && chainId !== 10 && chainId !== 69 && showNetworkAlert && (
+        <StickyNote>
+          <div
+            css={css`
+              display: flex;
+              align-items: center;
+            `}
+          >
+            <p
+              css={css`
+                margin-right: 10px;
+                padding-bottom: unset;
+              `}
+            >
+              You should switch to Optimism network to customize your hustler.
+            </p>{' '}
+            <CloseButton onClick={handleCloseAlert} />
+          </div>
+        </StickyNote>
+      )}
+      {walletLoading || loading || !data?.hustlers.edges?.[0]?.node || !router.isReady ? (
+        <ContentLoading />
+      ) : (
+        <HustlerInformations hustler={data.hustlers.edges[0].node} />
+      )}
+    </AppWindow>
+  );
+}

--- a/packages/web/src/pages/hustlers/index.tsx
+++ b/packages/web/src/pages/hustlers/index.tsx
@@ -171,7 +171,7 @@ const Hustlers = () => {
             {data.wallets.edges[0].node.hustlers.map(({ id, svg, name }) => {
               if (!svg) return null;
               return (
-                <Link key={id} href={`/hustlers/${id}/customize`}>
+                <Link key={id} href={`/hustlers/${id}/details`}>
                   <a>
                     <RenderFromChain
                       data={{

--- a/packages/web/src/ui/components/DopeTabs/index.tsx
+++ b/packages/web/src/ui/components/DopeTabs/index.tsx
@@ -5,6 +5,7 @@ export type DopeTabType = { title: string; number?: number; content: ReactElemen
 
 type DopeTabsProps = {
   tabs: DopeTabType[];
+  height?: string;
 };
 
 const formatTitle = (title: string) =>
@@ -12,10 +13,10 @@ const formatTitle = (title: string) =>
     ? `${title.slice(0, 2)}..${title.slice(title.length - 4, title.length)}`
     : title;
 
-const DopeTabs = ({ tabs }: DopeTabsProps) => {
+const DopeTabs = ({ tabs, height }: DopeTabsProps) => {
   return (
     <Tabs>
-      <TabList padding="8px 8px 0 8px" backgroundColor="#222222">
+      <TabList  padding="0px 8px 0 8px">
         {tabs.map(tab => (
           <Tab
             marginRight="8px"
@@ -35,7 +36,9 @@ const DopeTabs = ({ tabs }: DopeTabsProps) => {
           >
             <Box flexGrow="1" />
             <Box flexGrow="1">
-              <Text margin="0">{formatTitle(tab.title)}</Text>
+              <Text margin="0" pb="0">
+                {formatTitle(tab.title)}
+              </Text>
             </Box>
             <Box flexGrow="1">
               {Boolean(tab.number) && (
@@ -57,9 +60,17 @@ const DopeTabs = ({ tabs }: DopeTabsProps) => {
         ))}
       </TabList>
 
-      <TabPanels>
-        {tabs.map(tab => (
-          <TabPanel>{tab.content}</TabPanel>
+      <TabPanels
+        h={height || "auto"}
+      >
+        {tabs.map((tab, index) => (
+          <TabPanel 
+            p="0"
+            key={`tab-${index}`}
+            h="100%"
+          >
+            {tab.content}
+          </TabPanel>
         ))}
       </TabPanels>
     </Tabs>


### PR DESCRIPTION
This pull request contains the first version of the hustler details + gear using Dope tabs:

Remarks:

- The respect field not returned at the moment from the backend
- Hustler's Tier color in Gears needs to be fixed on the backend side after that the color will be displayed in the frontend (already implemented in the front)

Todo:

- Dope tabs mobile style
- Dope tabs should be integrated with the header
- The actions should be added to the buttons (at the moment only the display)

