### PR TITLE
Attempt to fix order…still not persisting to chain

### DIFF
--- a/packages/web/src/components/hustler/ConfigurationControls.tsx
+++ b/packages/web/src/components/hustler/ConfigurationControls.tsx
@@ -107,7 +107,7 @@ const ConfigurationControls = ({
       // title
       bitoptions |= 0b10;
       // name
-      bitoptions += 0b100;
+      bitoptions |= 0b100;
     }
 
     const options =
@@ -133,7 +133,7 @@ const ConfigurationControls = ({
 
     // Viewbox / Zoomwindow
     if (zoomWindow[0].gt(0) || zoomWindow[0].gt(1) || zoomWindow[0].gt(2) || zoomWindow[0].gt(3)) {
-      bitmask |= 0b100;
+      bitmask |= 0b1000;
     }
 
     const mask =
@@ -144,6 +144,7 @@ const ConfigurationControls = ({
 
     console.log(bitmask);
     console.log(`bitmask: ${mask}`);
+    console.log(options);
 
     if (hustlers) {
       try {

--- a/packages/web/src/components/hustler/ConfigurationControls.tsx
+++ b/packages/web/src/components/hustler/ConfigurationControls.tsx
@@ -124,6 +124,8 @@ const ConfigurationControls = ({
     // 4-7: Bodyparts
     // 8: Layer order
     let bitmask = 111110110;
+    
+    // If anything in the name box at all, set it
     if (setname.length > 0) {
       bitmask += 1;
     }
@@ -138,6 +140,9 @@ const ConfigurationControls = ({
       parseInt('' + bitmask, 2)
         .toString(16)
         .padStart(4, '0');
+
+    console.log(bitmask);
+    console.log(`bitmask: ${mask}`);
 
     if (hustlers) {
       try {
@@ -163,11 +168,13 @@ const ConfigurationControls = ({
           //   'RING',
           //   'ACCESSORY'
           // ];
-          order: [2, 6, 8, 5, 1, 3, 4, 7, 0, 9],
+          order: [2, 6, 8, 5, 1, 3, 4, 7, 0, 9].map(i => BigNumber.from(i)),
         });
         await transaction.wait();
       } catch (error) {
+        setLoading(false);
         console.error(error);
+        return;
       }
       setLoading(false);
       router.push({

--- a/packages/web/src/components/hustler/ConfigurationControls.tsx
+++ b/packages/web/src/components/hustler/ConfigurationControls.tsx
@@ -97,22 +97,22 @@ const ConfigurationControls = ({
     ];
 
 
-    let bitoptions = 1000;
+    let bitoptions = 0b1000;
 
     if (isVehicle) {
-      bitoptions += 1;
+      bitoptions |= 0b1;
     }
 
     if (renderName) {
       // title
-      bitoptions += 10;
+      bitoptions |= 0b10;
       // name
-      bitoptions += 100;
+      bitoptions += 0b100;
     }
 
     const options =
       '0x' +
-      parseInt('' + bitoptions, 2)
+      bitoptions
         .toString(16)
         .padStart(4, '0');
 
@@ -124,21 +124,21 @@ const ConfigurationControls = ({
     // 3: Viewbox
     // 4-7: Bodyparts
     // 8: Layer order
-    let bitmask = 111110110;
+    let bitmask = 0b111110110;
     
     // If anything in the name box at all, set it
     if (setname.length > 0) {
-      bitmask += 1;
+      bitmask |= 0b1;
     }
 
     // Viewbox / Zoomwindow
     if (zoomWindow[0].gt(0) || zoomWindow[0].gt(1) || zoomWindow[0].gt(2) || zoomWindow[0].gt(3)) {
-      bitmask += 1000;
+      bitmask |= 0b100;
     }
 
     const mask =
       '0x' +
-      parseInt('' + bitmask, 2)
+        bitmask
         .toString(16)
         .padStart(4, '0');
 

--- a/packages/web/src/components/hustler/ConfigurationControls.tsx
+++ b/packages/web/src/components/hustler/ConfigurationControls.tsx
@@ -140,18 +140,31 @@ const ConfigurationControls = ({
           viewbox: zoomWindow,
           body: bodyParts,
           mask,
-          order: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          // SLOTS order as defined in HustlerMetadata.sol
+          // Human readable…
+          // const SLOTS = [
+          //   'WEAPON',
+          //   'CLOTHES',
+          //   'VEHICLE',
+          //   'WAIST',
+          //   'FOOT',
+          //   'HAND',
+          //   'DRUGS',
+          //   'NECK',
+          //   'RING',
+          //   'ACCESSORY'
+          // ];
+          order: [2, 6, 8, 5, 1, 3, 4, 7, 0, 9],
         });
         await transaction.wait();
-        setLoading(false);
-        router.push({
-          pathname: '/inventory',
-          search: `?section=Hustlers`,
-        });
       } catch (error) {
         console.error(error);
-        setLoading(false);
       }
+      setLoading(false);
+      router.push({
+        pathname: '/inventory',
+        search: `?section=Hustlers`,
+      });
     }
   }, [chainId, hustlers, config, router, web3ReactChainId]);
 

--- a/packages/web/src/components/hustler/ConfigurationControls.tsx
+++ b/packages/web/src/components/hustler/ConfigurationControls.tsx
@@ -96,7 +96,8 @@ const ConfigurationControls = ({
       sex == 'male' ? BigNumber.from(facialHair) : BigNumber.from(0),
     ];
 
-    let bitoptions = 0;
+
+    let bitoptions = 1000;
 
     if (isVehicle) {
       bitoptions += 1;
@@ -154,8 +155,10 @@ const ConfigurationControls = ({
           viewbox: zoomWindow,
           body: bodyParts,
           mask,
-          // SLOTS order as defined in HustlerMetadata.sol
+          // SLOTS order as defined in Components.sol:33
+          //
           // Human readable…
+          //
           // const SLOTS = [
           //   'WEAPON',
           //   'CLOTHES',

--- a/packages/web/src/components/hustler/ConfigurationControls.tsx
+++ b/packages/web/src/components/hustler/ConfigurationControls.tsx
@@ -115,11 +115,20 @@ const ConfigurationControls = ({
         .toString(16)
         .padStart(4, '0');
 
-    let bitmask = 11110110;
+    // Bitmask controls configuration options we're allowed to set 
+    // in Hustler.sol
+    // 0: Name
+    // 1: Color
+    // 2: Background Color
+    // 3: Viewbox
+    // 4-7: Bodyparts
+    // 8: Layer order
+    let bitmask = 111110110;
     if (setname.length > 0) {
       bitmask += 1;
     }
 
+    // Viewbox / Zoomwindow
     if (zoomWindow[0].gt(0) || zoomWindow[0].gt(1) || zoomWindow[0].gt(2) || zoomWindow[0].gt(3)) {
       bitmask += 1000;
     }

--- a/packages/web/src/generated/graphql.ts
+++ b/packages/web/src/generated/graphql.ts
@@ -620,7 +620,7 @@ export enum ItemType {
   Hand = 'HAND',
   Neck = 'NECK',
   Ring = 'RING',
-  Vehcile = 'VEHCILE',
+  Vehicle = 'VEHICLE',
   Waist = 'WAIST',
   Weapon = 'WEAPON'
 }

--- a/packages/web/src/hooks/render.ts
+++ b/packages/web/src/hooks/render.ts
@@ -12,7 +12,7 @@ const order = [
   ItemType.Ring,
   ItemType.Accessory,
   ItemType.Weapon,
-  ItemType.Vehcile,
+  ItemType.Vehicle,
 ];
 
 type Rles = Pick<Item, 'rles'> & {

--- a/packages/web/src/hooks/render.ts
+++ b/packages/web/src/hooks/render.ts
@@ -4,7 +4,6 @@ import { HustlerSex } from 'utils/HustlerConfig';
 
 const order = [
   ItemType.Clothes,
-  ItemType.Weapon,
   ItemType.Waist,
   ItemType.Foot,
   ItemType.Hand,
@@ -12,6 +11,7 @@ const order = [
   ItemType.Neck,
   ItemType.Ring,
   ItemType.Accessory,
+  ItemType.Weapon,
   ItemType.Vehcile,
 ];
 


### PR DESCRIPTION
The fix @nnons implemented works great to fix the client-side rendering of the hustler, but does not affect the on-chain representation.

This PR attempts to fix the order layer passed into the `hustler.setMetadata` contract method, but doesn't seem to be operating correctly. Changing the layer order of items in the call seems to do nothing.

**Client Render**
<img width="418" alt="image" src="https://user-images.githubusercontent.com/12508/156942677-3e7ea8c4-988c-4af9-a705-deaf2dcc3cb1.png">


**On Chain Render**
<img width="623" alt="image" src="https://user-images.githubusercontent.com/12508/156942670-861b59d3-4581-4940-a667-b4fdea68f1ba.png">

