### PR TITLE
Github Action: Deploy API/Indexer

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,0 +1,35 @@
+name: API
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - closed
+    paths:
+      - 'packages/api/**'
+jobs:
+  deploy_api:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+      - uses: 'actions/checkout@v3'
+
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v0.6.0'
+        with:
+          workload_identity_provider: 'projects/803405501117/locations/global/workloadIdentityPools/automation-pool/providers/automation-provider'
+          service_account: 'automation@dopewars-live.iam.gserviceaccount.com'
+
+      - id: 'deploy-api'
+        uses: 'google-github-actions/deploy-appengine@v0.8.0'
+        with:
+          deliverables: 'app.testnet.api.yaml'
+          
+      - id: 'deploy-indexer'
+        uses: 'google-github-actions/deploy-appengine@v0.8.0'
+        with:
+          deliverables: 'app.testnet.indexer.yaml'


### PR DESCRIPTION
README is still in progress. I probably wont include it in this particular PR.

When a branch is merged into master and something in the API folder has changed, this action will deploy the API and the indexer.

Google auth and app-engine packages used in this file are locked to a specific version instead of `latest`. I prefer to use locked versions for things auth related libs but we wont get potential security updates, and god knows we wont actually update versions once this goes live.

How should deploying to mainnet work?