### PR TITLE
Log post requests

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -44,7 +44,7 @@ At the time of this writing, [App Engine Standard Environment only supports up t
 
 #### Run these commands to deploy
 
-```
+```bash
 gcloud app deploy --appyaml app.mainnet.api.yaml
 gcloud app deploy --appyaml app.mainnet.indexer.yaml
 ```

--- a/packages/api/api.go
+++ b/packages/api/api.go
@@ -40,17 +40,18 @@ func NewHttpServer(ctx context.Context, drv *sql.Driver, static *storage.BucketH
 	}
 	ethClient := ethclient.NewClient(c)
 
-	srv := handler.NewDefaultServer(graph.NewSchema(client))
+	graphServer := handler.NewDefaultServer(graph.NewSchema(client))
 
 	r := mux.NewRouter()
 	r.Use(middleware.Session(middleware.Store))
+	r.Use(middleware.Logger)
 
 	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		_, _ = w.Write([]byte(`{"success":true}`))
 	})
 	r.Handle("/playground", playground.Handler("GraphQL playground", "/query"))
-	r.Handle("/query", srv)
+	r.Handle("/query", graphServer)
 
 	authRouter := r.PathPrefix("/authentication").Subrouter()
 	authRouter.Use(authentication.CORS())

--- a/packages/api/middleware/logger.go
+++ b/packages/api/middleware/logger.go
@@ -1,0 +1,19 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+)
+
+func Logger(nextHandler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Debug().
+			Str("path", r.URL.Path).
+			Str("query", fmt.Sprintf("%s", r.URL.Query())).
+			Str("body", fmt.Sprintf("%s", r.Body)).
+			Send()
+		nextHandler.ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
Use `stdout` to write paths, querystrings, and post bodies so I can debug things.
https://cloud.google.com/appengine/docs/standard/go/writing-application-logs