### PR TITLE
Fix OpenSea Go Indexer Code

### DIFF
--- a/packages/api/.gitignore
+++ b/packages/api/.gitignore
@@ -1,1 +1,2 @@
 pgdata
+tmp

--- a/packages/api/cmd/openseaIndexer/main.go
+++ b/packages/api/cmd/openseaIndexer/main.go
@@ -2,13 +2,17 @@ package main
 
 import (
 	"context"
+	"os"
 
 	"github.com/dopedao/dope-monorepo/packages/api/indexer"
 	"github.com/dopedao/dope-monorepo/packages/api/internal/dbprovider"
 	"github.com/dopedao/dope-monorepo/packages/api/internal/envcfg"
+	"github.com/rs/zerolog"
 )
 
 func main() {
+	log := zerolog.New(os.Stderr)
+	ctx := context.Background()
 	var oscfg indexer.OpenseaConfig
 
 	for _, c := range indexer.Config[envcfg.Network] {
@@ -18,6 +22,8 @@ func main() {
 		}
 	}
 
+	log.Info().Msg("Starting OpenSea Indexer")
+
 	indexer := indexer.NewOpenseaIndexer(dbprovider.Ent(), oscfg)
-	indexer.Sync(context.Background())
+	indexer.Sync(log.WithContext(ctx))
 }

--- a/packages/api/go.mod
+++ b/packages/api/go.mod
@@ -30,6 +30,9 @@ require (
 	google.golang.org/genproto v0.0.0-20220422154200-b37d22cd5731
 )
 
-require github.com/btcsuite/btcd v0.22.0-beta // indirect
+require (
+	github.com/btcsuite/btcd v0.22.0-beta // indirect
+	github.com/k0kubun/pp v3.0.1+incompatible // indirect
+)
 
 // replace entgo.io/contrib => github.com/tarrencev/contrib v0.0.0-20220114171150-7eb36888a822

--- a/packages/api/go.sum
+++ b/packages/api/go.sum
@@ -508,6 +508,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/jwilder/encoding v0.0.0-20170811194829-b4e1701a28ef/go.mod h1:Ct9fl0F6iIOGgxJ5npU/IUOhOhqlVrGjyIZc8/MagT0=
+github.com/k0kubun/pp v3.0.1+incompatible h1:3tqvf7QgUnZ5tXO6pNAZlrvHgl6DvifjDrd9g2S9Z40=
+github.com/k0kubun/pp v3.0.1+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/karalabe/usb v0.0.2/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/kevinmbeaulieu/eq-go v1.0.0/go.mod h1:G3S8ajA56gKBZm4UB9AOyoOS37JO3roToPzKNM8dtdM=

--- a/packages/api/indexer/config.go
+++ b/packages/api/indexer/config.go
@@ -8,8 +8,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-var osKeyVal, _ = envcfg.OpenSeaApiKey.Value()
-
 type ConfigCollection []interface{}
 
 var Config = map[string]ConfigCollection{
@@ -59,7 +57,7 @@ var Config = map[string]ConfigCollection{
 			},
 		},
 		OpenseaConfig{
-			APIKey:   osKeyVal,
+			APIKey:   envcfg.OpenSeaApiKey,
 			URL:      "https://api.opensea.io",
 			Contract: "0x8707276df042e89669d69a177d3da7dc78bd8723",
 			Interval: time.Minute * 20,
@@ -111,7 +109,7 @@ var Config = map[string]ConfigCollection{
 			},
 		},
 		OpenseaConfig{
-			APIKey:   osKeyVal,
+			APIKey:   envcfg.OpenSeaApiKey,
 			URL:      "https://api.opensea.io",
 			Contract: "0x8707276df042e89669d69a177d3da7dc78bd8723",
 			Interval: time.Minute * 600,

--- a/packages/api/internal/dbprovider/dbprovider.go
+++ b/packages/api/internal/dbprovider/dbprovider.go
@@ -20,16 +20,13 @@ import (
 var dbConnection *sql.Driver
 var entClient *ent.Client
 
-var pgHost = flag.GetEnvOrFallback("PG_HOST", "localhost:5432")
-var pgPass = flag.GetEnvOrFallback("PG_PASS", "postgres")
-
-// "plaintext://postgres://postgres:postgres@localhost:5432?sslmode=disable"
-
 func init() {
 	// Load PG connection string from env
+	var pgHost = flag.GetEnvOrFallback("PG_HOST", "localhost:5432")
+	var pgPass = flag.GetEnvOrFallback("PG_PASS", "postgres")
 	connStr := flag.SecretEnv("PG_CONNSTR",
 		fmt.Sprintf(
-			"plaintext://postgres://postgres:%s@%s?sslmode=disable",
+			"postgres://postgres:%s@%s?sslmode=disable",
 			pgPass, pgHost))
 	pgsVal, connErr := connStr.Value()
 	logger.LogFatalOnErr(connErr, "Getting postgres connection string.")

--- a/packages/api/internal/envcfg/envcfg.go
+++ b/packages/api/internal/envcfg/envcfg.go
@@ -3,14 +3,26 @@ package envcfg
 
 import (
 	"github.com/dopedao/dope-monorepo/packages/api/internal/flag"
+	"github.com/dopedao/dope-monorepo/packages/api/internal/logger"
 	"github.com/spf13/pflag"
 )
 
-// Listen to env variable PORT or default to 8080
-// to avoid warning GCP was giving us about this issue.
-// https://cloud.google.com/appengine/docs/flexible/custom-runtimes/configuring-your-app-with-app-yaml
-var port = flag.GetEnvOrFallback("PORT", "8080")
-var Listen = pflag.String("listen", port, "server listen port")
+var Listen *string
+var OpenSeaApiKey string
+var Network string
 
-var OpenSeaApiKey = flag.SecretEnv("OPENSEA", "plaintext://")
-var Network = flag.GetEnvOrFallback("NETWORK", "mainnet")
+func init() {
+	// Listen to env variable PORT or default to 8080
+	// to avoid warning GCP was giving us about this issue.
+	// https://cloud.google.com/appengine/docs/flexible/custom-runtimes/configuring-your-app-with-app-yaml
+	port := flag.GetEnvOrFallback("PORT", "8080")
+	Listen = pflag.String("listen", port, "server listen port")
+
+	Network = flag.GetEnvOrFallback("NETWORK", "mainnet")
+
+	osVal, err := flag.SecretEnv("OPENSEA", "plaintext://").Value()
+	if err != nil {
+		logger.LogFatalOnErr(err, "Env OPENSEA not set")
+	}
+	OpenSeaApiKey = osVal
+}

--- a/packages/api/internal/flag/flag.go
+++ b/packages/api/internal/flag/flag.go
@@ -48,7 +48,6 @@ type SecretValue struct {
 }
 
 func SecretEnv(env string, def string) *SecretValue {
-	fmt.Println("Getting value for env ", env)
 	v := os.Getenv(env)
 
 	if len(v) == 0 {

--- a/packages/api/internal/flag/flag.go
+++ b/packages/api/internal/flag/flag.go
@@ -1,3 +1,5 @@
+// Provides simple access for ENV variables,
+// and more complicated access to Google Secret managers
 package flag
 
 import (
@@ -12,6 +14,16 @@ import (
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	secretmanagerpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
 )
+
+// Allows specifying a fallback value if ENV variable isn't set
+func GetEnvOrFallback(key, fallback string) string {
+	value, ok := os.LookupEnv(key)
+	if !ok {
+		return fallback
+	} else {
+		return value
+	}
+}
 
 var (
 	smOnce sync.Once
@@ -29,16 +41,6 @@ func smClient() *secretmanager.Client {
 	return sm
 }
 
-// Allows specifying a fallback value if ENV variable isn't set
-func GetEnvOrFallback(key, fallback string) string {
-	value, ok := os.LookupEnv(key)
-	if !ok {
-		return fallback
-	} else {
-		return value
-	}
-}
-
 // Enables secret manager access for cli flags.
 type SecretValue struct {
 	name  string
@@ -46,13 +48,14 @@ type SecretValue struct {
 }
 
 func SecretEnv(env string, def string) *SecretValue {
-	name := os.Getenv(env)
+	fmt.Println("Getting value for env ", env)
+	v := os.Getenv(env)
 
-	if len(name) == 0 {
-		name = def
+	if len(v) == 0 {
+		v = def
 	}
 
-	sv := SecretValue{name: name}
+	sv := SecretValue{name: env, value: v}
 	return &sv
 }
 


### PR DESCRIPTION
Fixed OpenSea indexer + added logging for monitoring
    
We needed to add the `include_orders=true` query string, which seems to be a new thing with OpenSea's API. We depend on those Order records in the JSON response to fill out orders (and prices) for item sales.
    
Assuming our updated API key continues to work, this will now properly pull the correct prices for items on sale, and add some logging that is necessary to ensure that we can monitor the health of this service in production.